### PR TITLE
release/0.9.0 (#70)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,5 @@
+since lines shift from edits, audit and revise the line ranges referenced in this file when instructed. include function and module comments in line range revisions
+
 skip caps when starting sentences
 
 skip periods on single sentence paragraphs
@@ -30,27 +32,27 @@ complete all reading instructions immediately upon starting any conversation. do
 
 read ./README.md and the ./math-1-0.md geometric number spec
 
-learn how geonum implements the dual in src/angle.rs:350~407
+learn how geonum implements the dual in src/angle.rs:342~370
 
-learn how geonum defines geometric grades with the mod_4_blade function in src/angle.rs:184~190 and the grade function in src/angle.rs:145~162
+learn how geonum defines geometric grades with the grade function in src/angle.rs:145~182
 
-learn how angle impls PartialEq and Eq in src/angle.rs:409~427
+learn how angle impls PartialEq and Eq in src/angle.rs:412~430
 
-learn how angle overloads arithmetic operators in src/angle.rs:430~576
+learn how angle overloads arithmetic operators in src/angle.rs:432~603
 
-learn about the geometric_add and normalize_boundaries functions in src/angle.rs:220~286
+learn about the geometric_add and normalize_boundaries functions in src/angle.rs:211~324
 
-learn how geonum overloads arithmetic operators in src/geonum_mod.rs:700~993
+learn how geonum overloads arithmetic operators in src/geonum_mod.rs:710~1003
 
 learn how to construct angles with new and new_with_blade from src/angle.rs:22~96
 
-learn how to construct geonum with new, new_with_angle from src/geonum_mod.rs:23~49
+learn how to construct geonum with new, new_with_angle from src/geonum_mod.rs:22~49
 
 learn how geonum can express any number type from the its_a_scalar, its_a_vector, its_a_real_number, its_an_imaginary_number, its_a_complex_number, its_a_quaternion, its_a_dual_number, its_an_octonion tests in tests/numbers_test.rs:1~395
 
 learn how geonum eliminates angle slack created by decomposing angles into scalar coefficients by reading from the top of tests/linear_algebra_test.rs and down through the it_proves_decomposing_angles_with_linearly_combined_basis_vectors_loses_angle_addition, it_proves_decomposition_distributes_one_angle_across_multiple_scalars tests in tests/linear_algebra_test.rs:1~160
 
-learn how geonum replaces scalar based quadratic forms with simple angle based rotations in the it_proves_rotational_quadrature_expresses_quadratic_forms test available in tests/dimension_test.rs:1417~1592
+learn how geonum replaces scalar based quadratic forms with simple angle based rotations in the it_proves_rotational_quadrature_expresses_quadratic_forms test available in tests/dimension_test.rs:1421~1595
 
 learn why dimensions are an unnecessary abstraction the it_proves_quadrature_creates_dimensional_structure,  it_shows_dimensions_are_quarter_turns tests in tests/dimension_test.rs:87~198
 
@@ -58,10 +60,10 @@ learn why geonum deprecates grade decomposition in the it_proves_grade_decomposi
 
 learn how geonum maps grades with the it_replaces_k_to_n_minus_k_with_k_to_4_minus_k test in tests/dimension_test.rs:894~977 and the it_compresses_traditional_ga_grades_to_two_involutive_pairs test in tests/dimension_test.rs:1126~1162
 
-learn about angle forward only geometry from the it_sets_angle_forward_geometry_as_primitive test in tests/dimension_test.rs:1246~1379
+learn about angle forward only geometry from the it_sets_angle_forward_geometry_as_primitive test in tests/dimension_test.rs:1249~1383
 
 read only tests/angle_arithmetic_test.rs:1~20 because the file is large, but you can learn about the angle forward only blade arithmetic of operations from this file
 
 read the it_computes_limits test in tests/calculus_test.rs:7~259 and the it_proves_differentiation_cycles_grades in tests/calculus_test.rs:98~259 to understand how geonum automates calculus
 
-tests are styled as trojan horses for simplicity. conventional jargon promising symbol salad but readers get simple arithmetic in test contents. example tests: 1. it_handles_conformal_split in tests/cga_test.rs:4764~4879, 2. it_handles_inversive_distance in tests/cga_test.rs:4880~5011
+tests are styled as trojan horses for simplicity. conventional jargon promising symbol salad but readers get simple arithmetic in test contents. example tests: 1. it_handles_conformal_split in tests/cga_test.rs:4784~4899, 2. it_handles_inversive_distance in tests/cga_test.rs:4900~5031

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # changelog
 
+## 0.9.0 (2025-01-09)
+
+### removed
+- **BREAKING**: removed `pub fn to_cartesian()` crutch function from `Geonum`
+  - function encouraged escaping the geometric domain to raw coordinates
+  - all internal usage replaced with inline trigonometry where needed
+  - tests updated to use geometric operations (`adj()`, `opp()`) or inline projection
+
+  ### changed
+  - `mod_4_blade()` Geonum function changed to `grade_angle()`
+
 ## 0.8.1 (2025-09-15)
 
 ### added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # changelog
 
-## 0.9.0 (2025-01-09)
+## 0.9.0 (2025-09-19)
 
 ### removed
 - **BREAKING**: removed `pub fn to_cartesian()` crutch function from `Geonum`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "geonum"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "geonum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geonum"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/mxfactorial/geonum"
 description = "geometric number library supporting unlimited dimensions with O(1) complexity"

--- a/README.md
+++ b/README.md
@@ -58,12 +58,30 @@ struct Geonum {
     }
 }
 ```
-
-* dimensions = blade, how many dimensions the angle spans
 * project(onto: Angle) -> angle_diff.cos() into any dimension without defining it first
 * dual() = blade + 2, duality operation adds π rotation and involutively maps grades (0 ↔ 2, 1 ↔ 3)
 * grade() = blade % 4, geometric grade
+* differentiate() = angle + π/2, polynomial coefficients computed from sin(θ+π/2) = cos(θ) quadrature identity
 * replaces "pseudoscalar" with blade arithmetic
+
+### how dimensions work
+
+dimensions = blade, how many dimensions the angle spans
+
+traditional: dimensions are coordinate axes - you stack more coordinates
+
+Geonum: dimensions are rotational states - you rotate by π/2 increments
+
+| dimension | traditional | Geonum |
+|-----------|-------------|--------|
+| 1D | (x)  | `[length, 0]` |
+| 2D | (x, y)  | `[length, π/2]` |
+| 3D | (x, y, z) | `[length, π]` |
+| 4D | (x, y, z, w) | `[length, 3π/2]` |
+
+geometric numbers break numbers free from pencil & paper math requiring everything to be described as scalars and roman numeral stacked arrays of scalars
+
+a bladed angle lets them travel and transform freely without ever needing to know which dimension theyre in or facing
 
 ### use
 
@@ -209,7 +227,7 @@ all geonum operations maintain constant time regardless of dimension, eliminatin
 - `.to_cartesian()` converts to (x, y) coordinates
 - angle predicates: `.is_scalar()`, `.is_vector()`, `.is_bivector()`, `.is_trivector()`
 - angle functions: `.sin()`, `.cos()`, `.tan()`, `.is_opposite()`
-- `.mod_4_angle()` returns angle within current π/2 segment
+- `.grade_angle()` returns grade-based angle representation in [0, 2π) for external interfaces
 
 ### tests
 ```

--- a/src/traits/electromagnetics.rs
+++ b/src/traits/electromagnetics.rs
@@ -71,7 +71,7 @@ impl Electromagnetics for Geonum {
     ) -> Self {
         let magnitude = constant.length * charge.length / distance.length.powf(power.length);
         // angle calculation for negative charges
-        let direction = if charge.angle.mod_4_angle().cos() >= 0.0 {
+        let direction = if charge.angle.grade_angle().cos() >= 0.0 {
             angle
         } else {
             angle + Angle::new(1.0, 1.0) // add π

--- a/src/traits/machine_learning.rs
+++ b/src/traits/machine_learning.rs
@@ -87,7 +87,7 @@ impl MachineLearning for Geonum {
     fn activate(&self, activation: Activation) -> Self {
         match activation {
             Activation::ReLU => Geonum {
-                length: if self.angle.mod_4_angle().cos() > 0.0 {
+                length: if self.angle.grade_angle().cos() > 0.0 {
                     self.length
                 } else {
                     0.0
@@ -95,11 +95,11 @@ impl MachineLearning for Geonum {
                 angle: self.angle,
             },
             Activation::Sigmoid => Geonum {
-                length: self.length / (1.0 + (-self.angle.mod_4_angle().cos()).exp()),
+                length: self.length / (1.0 + (-self.angle.grade_angle().cos()).exp()),
                 angle: self.angle,
             },
             Activation::Tanh => Geonum {
-                length: self.length * self.angle.mod_4_angle().cos().tanh(),
+                length: self.length * self.angle.grade_angle().cos().tanh(),
                 angle: self.angle,
             },
             Activation::Identity => *self,

--- a/src/traits/optics.rs
+++ b/src/traits/optics.rs
@@ -37,7 +37,7 @@ impl Optics for Geonum {
         // apply snells law as angle transformation
         let incident_angle = self.angle;
         let n_ratio = refractive_index.length;
-        let refracted_angle_value = (incident_angle.mod_4_angle().sin() / n_ratio).asin();
+        let refracted_angle_value = (incident_angle.grade_angle().sin() / n_ratio).asin();
         let refracted_angle = Angle::new(refracted_angle_value, PI);
 
         Geonum::new_with_angle(self.length, refracted_angle)
@@ -49,7 +49,7 @@ impl Optics for Geonum {
 
         // apply each zernike term
         for term in zernike_coefficients {
-            let mode_effect_value = term.length * (term.angle.mod_4_angle().sin() * 3.0).cos();
+            let mode_effect_value = term.length * (term.angle.grade_angle().sin() * 3.0).cos();
             let mode_effect = Angle::new(mode_effect_value, PI);
             perturbed_phase = perturbed_phase + mode_effect;
         }
@@ -81,7 +81,7 @@ impl Optics for Geonum {
         // new_h = A*h + B*theta
         // new_theta = C*h + D*theta
         // theta needs to be in radians for matrix multiplication
-        let theta_radians = theta.mod_4_angle();
+        let theta_radians = theta.grade_angle();
         let new_h = a.length * h + b.length * theta_radians;
         let new_theta_radians = c.length * h + d.length * theta_radians;
         let new_theta_angle = Angle::new(new_theta_radians, PI);
@@ -96,7 +96,7 @@ impl Optics for Geonum {
         let image_intensity = 1.0 / (mag * mag);
 
         // image point has inverted angle and scaled height
-        let image_angle_value = -self.angle.mod_4_angle().sin() / mag;
+        let image_angle_value = -self.angle.grade_angle().sin() / mag;
         let image_angle = Angle::new(image_angle_value, PI);
 
         Geonum::new_with_angle(self.length * image_intensity, image_angle)
@@ -121,7 +121,7 @@ mod tests {
 
         // prove angle is inverted and scaled based on sin transformation
         // magnify computes: image_angle = -sin(object_angle) / mag
-        let object_sin = object.angle.mod_4_angle().sin();
+        let object_sin = object.angle.grade_angle().sin();
         let expected_angle_value_2x = -object_sin / 2.0;
         let expected_angle_2x = Angle::new(expected_angle_value_2x, PI);
         assert_eq!(magnified_2x.angle, expected_angle_2x);
@@ -166,8 +166,8 @@ mod tests {
         // for thin lens: new_angle = atan2(h - h/f, h) = atan2(h(1-1/f), h) = atan(1-1/f)
         // since current implementation uses sin for both h and theta,
         // all rays get same output angle regardless of input
-        let sin1 = ray1.angle.mod_4_angle().sin();
-        let sin2 = ray2.angle.mod_4_angle().sin();
+        let sin1 = ray1.angle.grade_angle().sin();
+        let sin2 = ray2.angle.grade_angle().sin();
 
         // this assertion will fail, proving the bug
         assert!(

--- a/tests/addition_test.rs
+++ b/tests/addition_test.rs
@@ -37,7 +37,7 @@ fn it_adds_orthogonal_vectors() {
 
     assert!((sum.length - 5.0).abs() < EPSILON);
     let expected_phase = (4.0_f64).atan2(3.0);
-    assert!((sum.angle.mod_4_angle() - expected_phase).abs() < EPSILON);
+    assert!((sum.angle.grade_angle() - expected_phase).abs() < EPSILON);
 
     // history policy is preserved internally; direction and length are primary here
 }
@@ -51,10 +51,12 @@ fn it_adds_high_blades_and_preserves_history() {
     let sum = a + b;
 
     // direction modulo 2π matches cartesian result
-    let (x1, y1) = a.to_cartesian();
-    let (x2, y2) = b.to_cartesian();
+    let x1 = a.length * a.angle.grade_angle().cos();
+    let y1 = a.length * a.angle.grade_angle().sin();
+    let x2 = b.length * b.angle.grade_angle().cos();
+    let y2 = b.length * b.angle.grade_angle().sin();
     let expected_phase = (y1 + y2).atan2(x1 + x2);
-    assert!((sum.angle.mod_4_angle() - expected_phase).abs() < EPSILON);
+    assert!((sum.angle.grade_angle() - expected_phase).abs() < EPSILON);
 }
 
 #[test]
@@ -64,7 +66,7 @@ fn it_matches_projection_based_sum() {
     let b = Geonum::new(3.0, 1.0, 4.0); // [3, π/4]
 
     // δ = θb − θa in [0, 2π)
-    let delta = (b.angle.mod_4_angle() - a.angle.mod_4_angle()).rem_euclid(2.0 * PI);
+    let delta = (b.angle.grade_angle() - a.angle.grade_angle()).rem_euclid(2.0 * PI);
 
     // resolve b in a’s frame
     let adj = Geonum::cos(Angle::new(delta, PI)).scale(b.length);
@@ -117,8 +119,10 @@ fn it_accumulates_blades_in_general_case() {
     let sum = a + b;
 
     // verify geometric result matches expected
-    let (x1, y1) = a.to_cartesian();
-    let (x2, y2) = b.to_cartesian();
+    let x1 = a.length * a.angle.grade_angle().cos();
+    let y1 = a.length * a.angle.grade_angle().sin();
+    let x2 = b.length * b.angle.grade_angle().cos();
+    let y2 = b.length * b.angle.grade_angle().sin();
     let expected_length = ((x1 + x2).powi(2) + (y1 + y2).powi(2)).sqrt();
     assert!((sum.length - expected_length).abs() < EPSILON);
 
@@ -178,8 +182,10 @@ fn it_maintains_commutative_blade_accumulation() {
     assert_eq!(ab.angle, ba.angle);
 
     // a has blade 3 + π/6, b has blade 5 + π/4
-    let (x1, y1) = a.to_cartesian();
-    let (x2, y2) = b.to_cartesian();
+    let x1 = a.length * a.angle.grade_angle().cos();
+    let y1 = a.length * a.angle.grade_angle().sin();
+    let x2 = b.length * b.angle.grade_angle().cos();
+    let y2 = b.length * b.angle.grade_angle().sin();
     let cartesian_result = Geonum::new_from_cartesian(x1 + x2, y1 + y2);
     let expected = cartesian_result.angle
         + Angle::new(3.0, 2.0) // +3 blades from a

--- a/tests/affine_test.rs
+++ b/tests/affine_test.rs
@@ -30,10 +30,10 @@ fn its_a_translation() {
 
     // translation in geometric numbers is vector addition in polar form
     // the result is a combined displacement
-    let original_x = point.length * point.angle.mod_4_angle().cos();
-    let original_y = point.length * point.angle.mod_4_angle().sin();
-    let translate_x = translation_vector.length * translation_vector.angle.mod_4_angle().cos();
-    let translate_y = translation_vector.length * translation_vector.angle.mod_4_angle().sin();
+    let original_x = point.length * point.angle.grade_angle().cos();
+    let original_y = point.length * point.angle.grade_angle().sin();
+    let translate_x = translation_vector.length * translation_vector.angle.grade_angle().cos();
+    let translate_y = translation_vector.length * translation_vector.angle.grade_angle().sin();
 
     let expected_x = original_x + translate_x;
     let expected_y = original_y + translate_y;

--- a/tests/algorithms_test.rs
+++ b/tests/algorithms_test.rs
@@ -522,8 +522,8 @@ fn its_a_distributed_algorithm() {
         let mut sum_y = 0.0;
 
         for node in system {
-            sum_x += node.angle.mod_4_angle().cos();
-            sum_y += node.angle.mod_4_angle().sin();
+            sum_x += node.angle.grade_angle().cos();
+            sum_y += node.angle.grade_angle().sin();
         }
 
         // compute average angle (circular mean)
@@ -1001,7 +1001,7 @@ fn its_a_machine_learning_algorithm() {
                     // Use sine instead of cosine for better discrimination
                     // This helps prevent balanced weights leading to zero output
                     let weight_projection =
-                        self.weights[i].length * self.weights[i].angle.mod_4_angle().sin();
+                        self.weights[i].length * self.weights[i].angle.grade_angle().sin();
                     sum += input * weight_projection;
                 }
             }

--- a/tests/angle_arithmetic_test.rs
+++ b/tests/angle_arithmetic_test.rs
@@ -617,7 +617,7 @@ fn it_constructs_geonum_from_cartesian() {
     assert_eq!(geo1.length, 5.0); // pythagorean magnitude
     assert_eq!(geo1.angle.blade(), 0); // angle < π/2, no boundary crossing
     let expected_angle = 4.0_f64.atan2(3.0); // atan2 calculation
-    assert!((geo1.angle.mod_4_angle() - expected_angle).abs() < EPSILON); // preserves atan2 result
+    assert!((geo1.angle.grade_angle() - expected_angle).abs() < EPSILON); // preserves atan2 result
                                                                           // blade arithmetic: cartesian → polar → blade decomposition
 
     // case 2: unit circle quadrants (exact blade boundaries)
@@ -1859,8 +1859,8 @@ fn it_implements_geonum_add_trait_blade_accumulation() {
     let backward = Geonum::new_with_blade(4.0, 50, 0.0, 1.0); // blade=50, angle=π (opposite direction)
 
     // prove they point in opposite directions
-    assert!((forward.angle.mod_4_angle() - 0.0).abs() < EPSILON); // forward at 0
-    assert!((backward.angle.mod_4_angle() - PI).abs() < EPSILON); // backward at π
+    assert!((forward.angle.grade_angle() - 0.0).abs() < EPSILON); // forward at 0
+    assert!((backward.angle.grade_angle() - PI).abs() < EPSILON); // backward at π
     assert_eq!(forward.length, backward.length); // same magnitude
 
     let oppose_sum = forward + backward;

--- a/tests/astrophysics_test.rs
+++ b/tests/astrophysics_test.rs
@@ -97,7 +97,7 @@ fn it_computes_gravitational_influence_through_angle_correlation() {
     // 3. prove orbital mechanics emerge from angle evolution
 
     // after gravitational influence, stars maintain orbital relationship
-    let final_angle_diff = (stars[1].angle - stars[0].angle).mod_4_angle();
+    let final_angle_diff = (stars[1].angle - stars[0].angle).grade_angle();
 
     // stars remain roughly opposite each other (π ± small change)
     assert!((final_angle_diff - PI).abs() < 0.5);
@@ -156,7 +156,7 @@ fn it_demonstrates_orbital_mechanics_through_angle_evolution() {
     }
 
     // verify orbit completed full circle
-    let final_angle = planet.angle.mod_4_angle();
+    let final_angle = planet.angle.grade_angle();
     assert!(
         !(0.1..=2.0 * PI - 0.1).contains(&final_angle),
         "orbit completes circle"
@@ -216,12 +216,12 @@ fn it_solves_three_body_problem_through_angle_correlation() {
     // track center of mass to prove conservation
     let initial_com_x: f64 = bodies
         .iter()
-        .map(|b| b.length * b.angle.mod_4_angle().cos())
+        .map(|b| b.length * b.angle.grade_angle().cos())
         .sum::<f64>()
         / 3.0;
     let initial_com_y: f64 = bodies
         .iter()
-        .map(|b| b.length * b.angle.mod_4_angle().sin())
+        .map(|b| b.length * b.angle.grade_angle().sin())
         .sum::<f64>()
         / 3.0;
 
@@ -240,7 +240,7 @@ fn it_solves_three_body_problem_through_angle_correlation() {
                     let r2 = bodies[j].length;
                     let angle_diff = bodies[j].angle - bodies[i].angle;
                     let dist_sq =
-                        r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.mod_4_angle().cos();
+                        r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.grade_angle().cos();
 
                     // gravitational influence as angle rate
                     // no force vectors - just angle change rate
@@ -248,7 +248,7 @@ fn it_solves_three_body_problem_through_angle_correlation() {
                     let angular_accel = influence_magnitude / (r1.max(EPSILON));
 
                     // direction of influence (toward other body)
-                    let direction = angle_diff.mod_4_angle().sin();
+                    let direction = angle_diff.grade_angle().sin();
 
                     angle_changes[i] =
                         angle_changes[i] + Angle::new(angular_accel * direction * dt * dt, PI);
@@ -269,10 +269,10 @@ fn it_solves_three_body_problem_through_angle_correlation() {
         // update positions through velocities
         for i in 0..3 {
             // convert to cartesian for position update (temporary)
-            let pos_x = bodies[i].length * bodies[i].angle.mod_4_angle().cos()
-                + velocities[i].length * velocities[i].angle.mod_4_angle().cos() * dt;
-            let pos_y = bodies[i].length * bodies[i].angle.mod_4_angle().sin()
-                + velocities[i].length * velocities[i].angle.mod_4_angle().sin() * dt;
+            let pos_x = bodies[i].length * bodies[i].angle.grade_angle().cos()
+                + velocities[i].length * velocities[i].angle.grade_angle().cos() * dt;
+            let pos_y = bodies[i].length * bodies[i].angle.grade_angle().sin()
+                + velocities[i].length * velocities[i].angle.grade_angle().sin() * dt;
 
             bodies[i] = Geonum::new_from_cartesian(pos_x, pos_y);
         }
@@ -283,12 +283,12 @@ fn it_solves_three_body_problem_through_angle_correlation() {
     // 1. center of mass stays fixed (momentum conservation)
     let final_com_x: f64 = bodies
         .iter()
-        .map(|b| b.length * b.angle.mod_4_angle().cos())
+        .map(|b| b.length * b.angle.grade_angle().cos())
         .sum::<f64>()
         / 3.0;
     let final_com_y: f64 = bodies
         .iter()
-        .map(|b| b.length * b.angle.mod_4_angle().sin())
+        .map(|b| b.length * b.angle.grade_angle().sin())
         .sum::<f64>()
         / 3.0;
 
@@ -304,7 +304,7 @@ fn it_solves_three_body_problem_through_angle_correlation() {
             let r1 = bodies[i].length;
             let r2 = bodies[j].length;
             let angle_diff = bodies[j].angle - bodies[i].angle;
-            let dist = (r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.mod_4_angle().cos()).sqrt();
+            let dist = (r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.grade_angle().cos()).sqrt();
             distances.push(dist);
         }
     }
@@ -409,7 +409,7 @@ fn it_proves_n_body_scales_linearly_through_angle_dynamics() {
                     // influence based on angular proximity (always small for neighbors)
                     let influence_rate = 1.0 / (radial_diff + 1.0);
                     influence_sum = influence_sum
-                        + Angle::new(influence_rate * 0.01 * angle_diff.mod_4_angle().cos(), PI);
+                        + Angle::new(influence_rate * 0.01 * angle_diff.grade_angle().cos(), PI);
                 }
             }
 
@@ -750,7 +750,7 @@ fn it_generates_spiral_structure_through_differential_angle_rates() {
     for i in 1..stars.len() {
         if (stars[i].length - stars[i - 1].length).abs() < 0.5 {
             // compare stars at similar radii
-            let local_angle_diff = (stars[i].angle - stars[i - 1].angle).mod_4_angle();
+            let local_angle_diff = (stars[i].angle - stars[i - 1].angle).grade_angle();
             angle_variance += local_angle_diff * local_angle_diff;
         }
     }
@@ -864,13 +864,13 @@ fn it_simulates_galaxy_collision_through_angle_interaction() {
     // measure initial configurations
     let initial_g1_com_x: f64 = galaxy1_stars
         .iter()
-        .map(|s| s.length * s.angle.mod_4_angle().cos())
+        .map(|s| s.length * s.angle.grade_angle().cos())
         .sum::<f64>()
         / galaxy1_size as f64;
 
     let initial_g2_com_x: f64 = galaxy2_stars
         .iter()
-        .map(|s| s.length * s.angle.mod_4_angle().cos())
+        .map(|s| s.length * s.angle.grade_angle().cos())
         .sum::<f64>()
         / galaxy2_size as f64;
 
@@ -893,13 +893,13 @@ fn it_simulates_galaxy_collision_through_angle_interaction() {
         // compute center of mass for each galaxy
         let g1_com_x: f64 = galaxy1_stars
             .iter()
-            .map(|s| s.length * s.angle.mod_4_angle().cos())
+            .map(|s| s.length * s.angle.grade_angle().cos())
             .sum::<f64>()
             / galaxy1_size as f64;
 
         let g2_com_x: f64 = galaxy2_stars
             .iter()
-            .map(|s| s.length * s.angle.mod_4_angle().cos())
+            .map(|s| s.length * s.angle.grade_angle().cos())
             .sum::<f64>()
             / galaxy2_size as f64;
 
@@ -915,8 +915,8 @@ fn it_simulates_galaxy_collision_through_angle_interaction() {
             // galaxy 1 stars feel galaxy 2's angle field
             for star in &mut galaxy1_stars {
                 // distance to other galaxy's center
-                let dx = g2_com_x - star.length * star.angle.mod_4_angle().cos();
-                let dy = 0.0 - star.length * star.angle.mod_4_angle().sin();
+                let dx = g2_com_x - star.length * star.angle.grade_angle().cos();
+                let dy = 0.0 - star.length * star.angle.grade_angle().sin();
                 let dist_to_g2 = (dx * dx + dy * dy).sqrt();
 
                 if dist_to_g2 < 8.0 {
@@ -933,8 +933,8 @@ fn it_simulates_galaxy_collision_through_angle_interaction() {
 
             // galaxy 2 stars feel galaxy 1's angle field
             for star in &mut galaxy2_stars {
-                let dx = g1_com_x - star.length * star.angle.mod_4_angle().cos();
-                let dy = 0.0 - star.length * star.angle.mod_4_angle().sin();
+                let dx = g1_com_x - star.length * star.angle.grade_angle().cos();
+                let dy = 0.0 - star.length * star.angle.grade_angle().sin();
                 let dist_to_g1 = (dx * dx + dy * dy).sqrt();
 
                 if dist_to_g1 < 8.0 {
@@ -1128,8 +1128,8 @@ fn it_demonstrates_cluster_dynamics_through_collective_angles() {
     // measure initial cluster properties
     let initial_com: (f64, f64) = galaxy_positions.iter().fold((0.0, 0.0), |acc, g| {
         (
-            acc.0 + g.length * g.angle.mod_4_angle().cos(),
-            acc.1 + g.length * g.angle.mod_4_angle().sin(),
+            acc.0 + g.length * g.angle.grade_angle().cos(),
+            acc.1 + g.length * g.angle.grade_angle().sin(),
         )
     });
     let initial_com_r = ((initial_com.0 / num_galaxies as f64).powi(2)
@@ -1152,13 +1152,13 @@ fn it_demonstrates_cluster_dynamics_through_collective_angles() {
                 if i != j {
                     // distance between galaxies
                     let dx = galaxy_positions[j].length
-                        * galaxy_positions[j].angle.mod_4_angle().cos()
+                        * galaxy_positions[j].angle.grade_angle().cos()
                         - galaxy_positions[i].length
-                            * galaxy_positions[i].angle.mod_4_angle().cos();
+                            * galaxy_positions[i].angle.grade_angle().cos();
                     let dy = galaxy_positions[j].length
-                        * galaxy_positions[j].angle.mod_4_angle().sin()
+                        * galaxy_positions[j].angle.grade_angle().sin()
                         - galaxy_positions[i].length
-                            * galaxy_positions[i].angle.mod_4_angle().sin();
+                            * galaxy_positions[i].angle.grade_angle().sin();
                     let dist = (dx * dx + dy * dy).sqrt();
 
                     if dist < cluster_radius * 2.0 {
@@ -1184,14 +1184,14 @@ fn it_demonstrates_cluster_dynamics_through_collective_angles() {
 
             // position updates
             let dx =
-                galaxy_velocities[i].length * galaxy_velocities[i].angle.mod_4_angle().cos() * dt;
+                galaxy_velocities[i].length * galaxy_velocities[i].angle.grade_angle().cos() * dt;
             let dy =
-                galaxy_velocities[i].length * galaxy_velocities[i].angle.mod_4_angle().sin() * dt;
+                galaxy_velocities[i].length * galaxy_velocities[i].angle.grade_angle().sin() * dt;
 
             let new_x =
-                galaxy_positions[i].length * galaxy_positions[i].angle.mod_4_angle().cos() + dx;
+                galaxy_positions[i].length * galaxy_positions[i].angle.grade_angle().cos() + dx;
             let new_y =
-                galaxy_positions[i].length * galaxy_positions[i].angle.mod_4_angle().sin() + dy;
+                galaxy_positions[i].length * galaxy_positions[i].angle.grade_angle().sin() + dy;
 
             galaxy_positions[i] = Geonum::new_from_cartesian(new_x, new_y);
         }
@@ -1200,8 +1200,8 @@ fn it_demonstrates_cluster_dynamics_through_collective_angles() {
     // measure final cluster properties
     let final_com: (f64, f64) = galaxy_positions.iter().fold((0.0, 0.0), |acc, g| {
         (
-            acc.0 + g.length * g.angle.mod_4_angle().cos(),
-            acc.1 + g.length * g.angle.mod_4_angle().sin(),
+            acc.0 + g.length * g.angle.grade_angle().cos(),
+            acc.1 + g.length * g.angle.grade_angle().sin(),
         )
     });
     let final_com_r = ((final_com.0 / num_galaxies as f64).powi(2)
@@ -1396,7 +1396,7 @@ fn gravitational_influence(body1: &Geonum, body2: &Geonum, mass1: f64, mass2: f6
     let angle_diff = body2.angle - body1.angle;
 
     // distance using law of cosines in angle space
-    let distance_squared = r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.mod_4_angle().cos();
+    let distance_squared = r1 * r1 + r2 * r2 - 2.0 * r1 * r2 * angle_diff.grade_angle().cos();
 
     // gravitational influence magnitude
     let influence_magnitude = G_NORMALIZED * mass1 * mass2 / (distance_squared + EPSILON);
@@ -1405,7 +1405,7 @@ fn gravitational_influence(body1: &Geonum, body2: &Geonum, mass1: f64, mass2: f6
     let angular_acceleration = influence_magnitude / (mass1 * r1.max(EPSILON));
 
     // direction based on angle difference
-    let direction_sign = angle_diff.mod_4_angle().sin();
+    let direction_sign = angle_diff.grade_angle().sin();
 
     Angle::new(angular_acceleration * direction_sign * 0.01, PI)
 }

--- a/tests/calculus_test.rs
+++ b/tests/calculus_test.rs
@@ -46,7 +46,7 @@ fn it_computes_limits() {
 
     // prove v' = [1, pi/2]
     assert_eq!(v_prime.length, 1.0);
-    assert!((v_prime.angle.mod_4_angle() - PI / 2.0).abs() < EPSILON);
+    assert!((v_prime.angle.grade_angle() - PI / 2.0).abs() < EPSILON);
 
     // prove nilpotency using wedge product
     let self_wedge = v0.wedge(&v0);
@@ -61,7 +61,7 @@ fn it_computes_limits() {
 
     // prove v'' = -v
     assert_eq!(v_double_prime.length, v0.length);
-    assert!((v_double_prime.angle.mod_4_angle() - PI).abs() < EPSILON);
+    assert!((v_double_prime.angle.grade_angle() - PI).abs() < EPSILON);
 
     // prove the 4-cycle property by computing v''' and v''''
     let v_triple_prime = Geonum::new_with_angle(
@@ -71,7 +71,7 @@ fn it_computes_limits() {
 
     // v''' = [1, 3pi/2] = -v'
     assert_eq!(v_triple_prime.length, v_prime.length);
-    assert!((v_triple_prime.angle.mod_4_angle() - 3.0 * PI / 2.0).abs() < EPSILON);
+    assert!((v_triple_prime.angle.grade_angle() - 3.0 * PI / 2.0).abs() < EPSILON);
 
     let v_quadruple_prime = Geonum::new_with_angle(
         v_triple_prime.length,
@@ -80,7 +80,7 @@ fn it_computes_limits() {
 
     // v'''' = [1, 0] = original v
     assert_eq!(v_quadruple_prime.length, v0.length);
-    let angle_rad = v_quadruple_prime.angle.mod_4_angle();
+    let angle_rad = v_quadruple_prime.angle.grade_angle();
     assert!(angle_rad < EPSILON || (TAU - angle_rad) < EPSILON);
 
     // extend the demonstration with fifth derivative
@@ -91,7 +91,7 @@ fn it_computes_limits() {
 
     // v''''' = [1, pi/2] = v'
     assert_eq!(v_quintuple_prime.length, v_prime.length);
-    assert!((v_quintuple_prime.angle.mod_4_angle() - v_prime.angle.mod_4_angle()).abs() < EPSILON);
+    assert!((v_quintuple_prime.angle.grade_angle() - v_prime.angle.grade_angle()).abs() < EPSILON);
 }
 
 #[test]
@@ -197,11 +197,11 @@ fn it_proves_differentiation_cycles_grades() {
     let angle_90 = angle_0 + Angle::new(1.0, 2.0); // add π/2
 
     assert!(
-        (angle_0.mod_4_angle().cos() - angle_90.mod_4_angle().sin()).abs() < EPSILON,
+        (angle_0.grade_angle().cos() - angle_90.grade_angle().sin()).abs() < EPSILON,
         "cos(θ) = sin(θ+π/2)"
     );
     assert!(
-        (angle_0.mod_4_angle().sin() + angle_90.mod_4_angle().cos()).abs() < EPSILON,
+        (angle_0.grade_angle().sin() + angle_90.grade_angle().cos()).abs() < EPSILON,
         "sin(θ) = -cos(θ+π/2)"
     );
 
@@ -420,7 +420,7 @@ fn it_derives() {
     let rotated_angle = base_angle + Angle::new(1.0, 2.0); // +π/2
 
     assert!(
-        (base_angle.mod_4_angle().cos() - rotated_angle.mod_4_angle().sin()).abs() < EPSILON,
+        (base_angle.grade_angle().cos() - rotated_angle.grade_angle().sin()).abs() < EPSILON,
         "cos(θ) = sin(θ + π/2) enables differentiation"
     );
 
@@ -515,7 +515,7 @@ fn it_proves_quadrature_generates_polynomial_coefficients() {
     let rotated_angle = base_angle + Angle::new(1.0, 2.0); // +π/2
 
     assert!(
-        (base_angle.mod_4_angle().cos() - rotated_angle.mod_4_angle().sin()).abs() < EPSILON,
+        (base_angle.grade_angle().cos() - rotated_angle.grade_angle().sin()).abs() < EPSILON,
         "cos(θ) = sin(θ+π/2) fundamental quadrature"
     );
 
@@ -567,11 +567,11 @@ fn it_proves_quadrature_generates_polynomial_coefficients() {
 
     // quadrature relationships between phases
     assert!(
-        (phase_0.mod_4_angle().cos() - phase_90.mod_4_angle().sin()).abs() < EPSILON,
+        (phase_0.grade_angle().cos() - phase_90.grade_angle().sin()).abs() < EPSILON,
         "grade 0→1 transition via quadrature"
     );
     assert!(
-        (phase_90.mod_4_angle().cos() + phase_180.mod_4_angle().sin()).abs() < EPSILON,
+        (phase_90.grade_angle().cos() + phase_180.grade_angle().sin()).abs() < EPSILON,
         "grade 1→2 transition via quadrature"
     );
 

--- a/tests/computer_vision_test.rs
+++ b/tests/computer_vision_test.rs
@@ -52,7 +52,7 @@ fn its_a_feature_detector() {
     // 2. compute gradient direction and magnitude directly
 
     // gradient can be directly encoded in the feature angle
-    let gradient_direction = corner_feature.angle.mod_4_angle();
+    let gradient_direction = corner_feature.angle.grade_angle();
     let gradient_magnitude = corner_feature.length;
 
     // verify gradient direction is correct
@@ -93,7 +93,7 @@ fn its_a_feature_detector() {
     ); // vector (grade 1) - same feature type
 
     // compute match quality using angle distance
-    let angle_diff = (rotated_feature.angle - corner_feature.angle).mod_4_angle();
+    let angle_diff = (rotated_feature.angle - corner_feature.angle).grade_angle();
     let match_quality = 1.0 - angle_diff / PI;
 
     // prove close match (close to 1.0)
@@ -164,11 +164,11 @@ fn its_an_optical_flow_estimator() {
 
     // flow vector is the difference between frame2 and frame1 points
     // convert to cartesian for illustrative purposes
-    let frame1_x = frame1_point.length * frame1_point.angle.mod_4_angle().cos();
-    let frame1_y = frame1_point.length * frame1_point.angle.mod_4_angle().sin();
+    let frame1_x = frame1_point.length * frame1_point.angle.grade_angle().cos();
+    let frame1_y = frame1_point.length * frame1_point.angle.grade_angle().sin();
 
-    let frame2_x = frame2_point.length * frame2_point.angle.mod_4_angle().cos();
-    let frame2_y = frame2_point.length * frame2_point.angle.mod_4_angle().sin();
+    let frame2_x = frame2_point.length * frame2_point.angle.grade_angle().cos();
+    let frame2_y = frame2_point.length * frame2_point.angle.grade_angle().sin();
 
     // flow vector components
     let flow_x = frame2_x - frame1_x;
@@ -193,7 +193,7 @@ fn its_an_optical_flow_estimator() {
     let flow_grade_1 = Geonum::new_with_blade(
         flow_vector.length,
         1, // ensure vector (grade 1)
-        flow_vector.angle.mod_4_angle(),
+        flow_vector.angle.grade_angle(),
         PI,
     );
 
@@ -202,13 +202,13 @@ fn its_an_optical_flow_estimator() {
         Geonum::new_with_blade(
             flow_vector.length * 0.5, // half magnitude at coarser scale
             2,                        // bivector (grade 2) - coarser scale flow
-            flow_vector.angle.mod_4_angle(),
+            flow_vector.angle.grade_angle(),
             PI,
         ),
         Geonum::new_with_blade(
             flow_vector.length * 0.25, // quarter magnitude at coarsest scale
             3,                         // trivector (grade 3) - coarsest scale flow
-            flow_vector.angle.mod_4_angle(),
+            flow_vector.angle.grade_angle(),
             PI,
         ),
     ]); // optical flow at multiple scales
@@ -312,7 +312,7 @@ fn its_a_camera_calibration() {
 
     // compute reprojection error as an angle-based distance
     let angle_diff = observed_point.angle - projected_point.angle;
-    let reprojection_error = angle_diff.mod_4_angle().abs();
+    let reprojection_error = angle_diff.grade_angle().abs();
 
     // error should be non-zero but small
     assert!(reprojection_error > 0.0);
@@ -349,7 +349,7 @@ fn its_a_camera_calibration() {
         .iter()
         .map(|camera| {
             // compute relative angle between camera and world point
-            let relative_angle = world_point.angle.mod_4_angle() - camera.angle.mod_4_angle();
+            let relative_angle = world_point.angle.grade_angle() - camera.angle.grade_angle();
 
             // projection depends on relative angle
             let visible = relative_angle.abs() < PI / 2.0; // only visible in front of camera
@@ -419,7 +419,7 @@ fn its_a_3d_reconstruction() {
 
     // compute distance to epipolar line (simplified as angle difference)
     let angle_diff = candidate_match.angle - epipolar_line.angle;
-    let epipolar_distance = angle_diff.mod_4_angle().abs();
+    let epipolar_distance = angle_diff.grade_angle().abs();
 
     // should be close to epipolar line
     assert!(
@@ -447,7 +447,7 @@ fn its_a_3d_reconstruction() {
     let angle_diff = ray1_angle - ray2_angle;
     // Use absolute value for positive depth
     let depth1 =
-        f64::abs(baseline * ray2_angle.mod_4_angle().sin() / angle_diff.mod_4_angle().sin());
+        f64::abs(baseline * ray2_angle.grade_angle().sin() / angle_diff.grade_angle().sin());
 
     // reconstructed 3D point
     let reconstructed_point = Geonum::new_with_angle(depth1, ray1_angle);
@@ -474,7 +474,7 @@ fn its_a_3d_reconstruction() {
     let avg_length = observations.iter().map(|o| o.length).sum::<f64>() / observations.len() as f64;
     let avg_angle = observations
         .iter()
-        .map(|o| o.angle.mod_4_angle())
+        .map(|o| o.angle.grade_angle())
         .sum::<f64>()
         / observations.len() as f64;
 
@@ -674,9 +674,9 @@ fn its_a_neural_image_processing() {
     // with geonum: direct angle-based nonlinearities
 
     // ReLU-like activation: preserve positive parts of signal
-    let activated_output = if layer_output.angle.mod_4_angle().cos() > 0.0 {
+    let activated_output = if layer_output.angle.grade_angle().cos() > 0.0 {
         Geonum::new_with_angle(
-            layer_output.length * layer_output.angle.mod_4_angle().cos(),
+            layer_output.length * layer_output.angle.grade_angle().cos(),
             layer_output.angle,
         )
     } else {
@@ -684,7 +684,7 @@ fn its_a_neural_image_processing() {
     };
 
     // verify activation has expected behavior
-    if layer_output.angle.mod_4_angle().cos() > 0.0 {
+    if layer_output.angle.grade_angle().cos() > 0.0 {
         assert!(
             activated_output.length > 0.0,
             "ReLU should preserve positive signals"
@@ -732,9 +732,9 @@ fn its_a_neural_image_processing() {
                 );
 
                 // simplified activation
-                if output.angle.mod_4_angle().cos() > 0.0 {
+                if output.angle.grade_angle().cos() > 0.0 {
                     Geonum::new_with_angle(
-                        output.length * output.angle.mod_4_angle().cos(),
+                        output.length * output.angle.grade_angle().cos(),
                         output.angle,
                     )
                 } else {
@@ -773,11 +773,12 @@ fn its_a_segmentation_algorithm() {
     // with geonum: direct angle-based clustering
 
     // create pixels with similar but noisy orientations
-    let num_pixels = 100;
+    let num_pixels: i32 = 100;
     let pixels = (0..num_pixels)
         .map(|i| {
             // add noise to orientation
-            let noise = (i as f64 / num_pixels as f64) * 0.2 - 0.1;
+            let index = f64::from(i);
+            let noise = (index / f64::from(num_pixels)) * 0.2 - 0.1;
             Geonum::new_with_angle(1.0, region_orientation.angle + Angle::new(noise, PI))
         })
         .collect::<Vec<Geonum>>();
@@ -786,18 +787,18 @@ fn its_a_segmentation_algorithm() {
 
     // calculate mean orientation
     let mean_angle =
-        pixels.iter().map(|p| p.angle.mod_4_angle()).sum::<f64>() / pixels.len() as f64;
+        pixels.iter().map(|p| p.angle.grade_angle()).sum::<f64>() / pixels.len() as f64;
 
     // verify mean is close to original region orientation
     assert!(
-        (mean_angle - region_orientation.angle.mod_4_angle()).abs() < 0.1,
+        (mean_angle - region_orientation.angle.grade_angle()).abs() < 0.1,
         "Mean orientation should be close to region orientation"
     );
 
     // calculate circular variance
     let circular_variance = pixels
         .iter()
-        .map(|p| 1.0 - f64::cos(p.angle.mod_4_angle() - mean_angle))
+        .map(|p| 1.0 - f64::cos(p.angle.grade_angle() - mean_angle))
         .sum::<f64>()
         / pixels.len() as f64;
 
@@ -815,7 +816,7 @@ fn its_a_segmentation_algorithm() {
 
     // boundary strength is angle difference
     let angle_diff = region1_pixel.angle - region2_pixel.angle;
-    let boundary_strength = angle_diff.mod_4_angle().abs();
+    let boundary_strength = angle_diff.grade_angle().abs();
 
     // should detect strong boundary (PI/2 is 90 degrees)
     assert!(
@@ -870,8 +871,8 @@ fn its_an_object_detection() {
     // 2. represent bounding box directly with geometric numbers
 
     // compute bounding box center (simplified 2D case)
-    let center_x = 100.0 + 50.0 * object.angle.mod_4_angle().cos();
-    let center_y = 100.0 + 50.0 * object.angle.mod_4_angle().sin();
+    let center_x = 100.0 + 50.0 * object.angle.grade_angle().cos();
+    let center_y = 100.0 + 50.0 * object.angle.grade_angle().sin();
 
     // bounding box as center position + scale
     let bbox_angle = Geonum::new_from_cartesian(center_x, center_y).angle;
@@ -886,7 +887,7 @@ fn its_an_object_detection() {
     );
 
     // compute IoU-like similarity directly from angles and scales
-    let angle_diff = (bbox2.angle - bbox.angle).mod_4_angle();
+    let angle_diff = (bbox2.angle - bbox.angle).grade_angle();
     let scale_ratio = bbox.length.min(bbox2.length) / bbox.length.max(bbox2.length);
 
     // combine angle and scale similarity
@@ -926,7 +927,7 @@ fn its_an_object_detection() {
         assigned[i] = true;
 
         for j in i + 1..detections.len() {
-            let angle_diff = (detections[j].angle - detections[i].angle).mod_4_angle();
+            let angle_diff = (detections[j].angle - detections[i].angle).grade_angle();
             // Handle circular distance
             let angle_dist = angle_diff.min(2.0 * PI - angle_diff);
             if !assigned[j] && angle_dist < angle_threshold {

--- a/tests/dimension_test.rs
+++ b/tests/dimension_test.rs
@@ -43,7 +43,7 @@ fn it_projects_a_geonum_onto_coordinate_axes() {
     // each projection represents alignment with that blade space
 
     // test individual projections are trigonometrically consistent
-    let geonum_angle = final_geonum.angle.mod_4_angle();
+    let geonum_angle = final_geonum.angle.grade_angle();
     let expected_blade_0 = final_geonum.length * (geonum_angle - 0.0).cos(); // angle from blade 0
     let expected_blade_1 = final_geonum.length * (geonum_angle - PI / 2.0).cos(); // angle from blade 1
 
@@ -96,7 +96,7 @@ fn it_proves_quadrature_creates_dimensional_structure() {
     let entity = Geonum::new(1.0, 1.0, 6.0); // π/6 angle, unit magnitude
 
     // test the fundamental quadrature relationship: sin(θ+π/2) = cos(θ)
-    let theta = entity.angle.mod_4_angle();
+    let theta = entity.angle.grade_angle();
     let theta_plus_quarter = theta + PI / 2.0;
     assert!((theta.cos() - theta_plus_quarter.sin()).abs() < EPSILON);
     assert!((theta.sin() + theta_plus_quarter.cos()).abs() < EPSILON);
@@ -153,10 +153,10 @@ fn it_shows_dimensions_are_quarter_turns() {
     let constructed_dim_3 = Geonum::create_dimension(1.0, 3); // 3 quarter turns
 
     // these are separated by exactly π/2 rotations
-    assert!((constructed_dim_0.angle.mod_4_angle() - 0.0).abs() < EPSILON);
-    assert!((constructed_dim_1.angle.mod_4_angle() - PI / 2.0).abs() < EPSILON);
-    assert!((constructed_dim_2.angle.mod_4_angle() - PI).abs() < EPSILON);
-    assert!((constructed_dim_3.angle.mod_4_angle() - 3.0 * PI / 2.0).abs() < EPSILON);
+    assert!((constructed_dim_0.angle.grade_angle() - 0.0).abs() < EPSILON);
+    assert!((constructed_dim_1.angle.grade_angle() - PI / 2.0).abs() < EPSILON);
+    assert!((constructed_dim_2.angle.grade_angle() - PI).abs() < EPSILON);
+    assert!((constructed_dim_3.angle.grade_angle() - 3.0 * PI / 2.0).abs() < EPSILON);
 
     // rotating between dimensions proves they are angle positions
     let rotated_0_to_1 = constructed_dim_0.rotate(Angle::new(1.0, 2.0)); // +π/2
@@ -673,7 +673,8 @@ fn it_doesnt_need_a_pseudoscalar() {
     // geonum: unified operation without grade extraction
     let input = Geonum::new(1.0, 0.0, 1.0);
     let geonum_result = input.scale_rotate(scale_factor, Angle::new(rotation_angle, PI));
-    let (geonum_x, geonum_y) = geonum_result.to_cartesian();
+    let geonum_x = geonum_result.length * geonum_result.angle.grade_angle().cos();
+    let geonum_y = geonum_result.length * geonum_result.angle.grade_angle().sin();
     assert!((traditional_result[0] - geonum_x).abs() < 1e-10);
     assert!((traditional_result[1] - geonum_y).abs() < 1e-10);
 
@@ -801,7 +802,8 @@ fn it_demonstrates_pseudoscalar_elimination_benefits() {
     let rotation = Angle::new(1.0, 2.0); // π/2
     let rotated = point.rotate(rotation);
 
-    let (x, y) = rotated.to_cartesian();
+    let x = rotated.length * rotated.angle.grade_angle().cos();
+    let y = rotated.length * rotated.angle.grade_angle().sin();
     assert!((x - (-4.0)).abs() < EPSILON);
     assert!((y - 3.0).abs() < EPSILON);
 
@@ -820,7 +822,8 @@ fn it_demonstrates_pseudoscalar_elimination_benefits() {
     assert_eq!(composed, Angle::new(3.0, 4.0)); // 3π/4
 
     let final_point = point.rotate(composed);
-    let (fx, fy) = final_point.to_cartesian();
+    let fx = final_point.length * final_point.angle.grade_angle().cos();
+    let fy = final_point.length * final_point.angle.grade_angle().sin();
     assert!((fx - (-4.949)).abs() < 0.01);
     assert!((fy - (-0.707)).abs() < 0.01);
 
@@ -1021,7 +1024,7 @@ fn it_proves_angle_space_is_absolute() {
     // prove operations work with absolute positions, not relative signs
     let chain = angle_0 * angle_pi_4 * angle_pi_2 * angle_3pi_4 * angle_pi;
     let total_angle = 0.0 + PI / 4.0 + PI / 2.0 + 3.0 * PI / 4.0 + PI;
-    assert!((chain.angle.mod_4_angle() - (total_angle % (2.0 * PI))).abs() < EPSILON);
+    assert!((chain.angle.grade_angle() - (total_angle % (2.0 * PI))).abs() < EPSILON);
 
     // prove grade transformations are absolute position changes
     let scalar = Geonum::new_with_blade(1.0, 0, 0.0, 1.0); // grade 0
@@ -1427,7 +1430,7 @@ fn it_proves_rotational_quadrature_expresses_quadratic_forms() {
     println!(
         "Geonum: length={}, angle={:.3} rad",
         geonum.length,
-        geonum.angle.mod_4_angle()
+        geonum.angle.grade_angle()
     );
 
     // step 2: get projections through geonum's rotational interface
@@ -1437,7 +1440,7 @@ fn it_proves_rotational_quadrature_expresses_quadratic_forms() {
     println!("Rotational projections: x={:.3}, y={:.3}", proj_x, proj_y);
 
     // step 3: compute the same projections using traditional trigonometry
-    let angle = geonum.angle.mod_4_angle();
+    let angle = geonum.angle.grade_angle();
     let trig_x = geonum.length * angle.cos(); // traditional x = r*cos(θ)
     let trig_y = geonum.length * angle.sin(); // traditional y = r*sin(θ)
 
@@ -1584,7 +1587,7 @@ fn it_proves_rotational_quadrature_expresses_quadratic_forms() {
     );
 
     println!("\n✓ Complete causal chain proven:");
-    println!("  quadrature: sin(θ+π/2) = cos(θ)");
+    println!("  quadrature: t");
     println!("  → Orthogonal projections: cos(θ), sin(θ)");
     println!("  → Quadratic identity: sin²+cos²=1");
     println!("  → Projection equivalence: geonum rotational = trigonometric");

--- a/tests/economics_test.rs
+++ b/tests/economics_test.rs
@@ -34,11 +34,11 @@ fn it_models_business_cycles() {
         // similar to principal component analysis but with geometric meaning
         let weighted_x = indicators
             .iter()
-            .map(|i| i.length * i.angle.mod_4_angle().cos()) // x-component (horizontal axis)
+            .map(|i| i.length * i.angle.grade_angle().cos()) // x-component (horizontal axis)
             .sum::<f64>();
         let weighted_y = indicators
             .iter()
-            .map(|i| i.length * i.angle.mod_4_angle().sin()) // y-component (vertical axis)
+            .map(|i| i.length * i.angle.grade_angle().sin()) // y-component (vertical axis)
             .sum::<f64>();
 
         // compute aggregate cycle phase (direction in economic state space)
@@ -49,7 +49,7 @@ fn it_models_business_cycles() {
         // in a complete implementation, this returns as additional information
         let _cycle_momentum = indicators
             .iter()
-            .map(|i| i.length * i.angle.mod_4_angle().sin())
+            .map(|i| i.length * i.angle.grade_angle().sin())
             .sum::<f64>();
 
         // return the economic state as a geometric number:
@@ -80,7 +80,7 @@ fn it_models_business_cycles() {
 
     // interpret the cycle phase in economic terms
     // map the geometric angle to economic cycle phases
-    let cycle_phase = match cycle_state.angle.mod_4_angle() {
+    let cycle_phase = match cycle_state.angle.grade_angle() {
         a if (0.0..PI / 2.0).contains(&a) => "expansion", // first quadrant: growth phase
         a if (PI / 2.0..PI).contains(&a) => "peak",       // second quadrant: mature expansion
         a if (PI..3.0 * PI / 2.0).contains(&a) => "contraction", // third quadrant: declining activity
@@ -91,7 +91,7 @@ fn it_models_business_cycles() {
     // shows how quickly the economy moves through the cycle
     let cycle_velocity = indicators
         .iter()
-        .map(|i| i.length * i.angle.mod_4_angle().sin())
+        .map(|i| i.length * i.angle.grade_angle().sin())
         .sum::<f64>();
 
     // test the cycle detection produces meaningful results
@@ -119,7 +119,7 @@ fn it_models_business_cycles() {
     println!("───── business cycle analysis ─────");
     println!(
         "cycle position: {:.2} radians",
-        cycle_state.angle.mod_4_angle()
+        cycle_state.angle.grade_angle()
     );
     println!("current economic phase: {cycle_phase}");
     println!(
@@ -222,7 +222,7 @@ fn it_models_payroll_tax_impact_across_income_brackets() {
             // length = magnitude of spending change
             // angle = combined position in economic space
             let combined_angle =
-                (income_angle + region_angle + category_angle + policy.angle.mod_4_angle())
+                (income_angle + region_angle + category_angle + policy.angle.grade_angle())
                     % (2.0 * PI);
             Geonum::new(1.0 + policy_impact, combined_angle, PI)
         };
@@ -412,7 +412,7 @@ fn it_detects_early_recession_indicators() {
             // payment timing signal - weighted by transaction volume
             let payment_timing_signal = transactions
                 .iter()
-                .map(|(vol, timing, _, _)| vol.length * timing.angle.mod_4_angle().sin())
+                .map(|(vol, timing, _, _)| vol.length * timing.angle.grade_angle().sin())
                 .sum::<f64>()
                 / total_volume;
 
@@ -420,7 +420,7 @@ fn it_detects_early_recession_indicators() {
             let size_signal = transactions
                 .iter()
                 .map(|(vol, _, size, _)| {
-                    vol.length * (size.angle.mod_4_angle() - PI / 2.0).sin().abs()
+                    vol.length * (size.angle.grade_angle() - PI / 2.0).sin().abs()
                 })
                 .sum::<f64>()
                 / total_volume;
@@ -429,7 +429,7 @@ fn it_detects_early_recession_indicators() {
             let geographic_signal = transactions
                 .iter()
                 .map(|(vol, _, _, geo)| {
-                    vol.length * (geo.angle.mod_4_angle() - PI / 2.0).sin().abs()
+                    vol.length * (geo.angle.grade_angle() - PI / 2.0).sin().abs()
                 })
                 .sum::<f64>()
                 / total_volume;
@@ -970,12 +970,12 @@ fn it_models_global_trade_flows() {
         // compute weighted flow direction
         let weighted_x = trade_flows
             .iter()
-            .map(|f| f.length * f.angle.mod_4_angle().cos())
+            .map(|f| f.length * f.angle.grade_angle().cos())
             .sum::<f64>();
 
         let weighted_y = trade_flows
             .iter()
-            .map(|f| f.length * f.angle.mod_4_angle().sin())
+            .map(|f| f.length * f.angle.grade_angle().sin())
             .sum::<f64>();
 
         // compute total trade volume
@@ -997,7 +997,7 @@ fn it_models_global_trade_flows() {
 
     // detect trade imbalances through angle analysis
     // in perfect measurement, this should be zero due to conservation laws
-    let imbalance_magnitude = global_trade.angle.mod_4_angle().sin() * global_trade.length;
+    let imbalance_magnitude = global_trade.angle.grade_angle().sin() * global_trade.length;
     let balanced_trade_threshold = 0.05 * global_trade.length; // 5% measurement error threshold
 
     // prove model produces meaningful results
@@ -1053,8 +1053,8 @@ fn it_measures_economic_sectoral_balance() {
 
         // single iteration over sectors
         for sector in sectors {
-            flow_x += sector.length * sector.angle.mod_4_angle().cos();
-            flow_y += sector.length * sector.angle.mod_4_angle().sin();
+            flow_x += sector.length * sector.angle.grade_angle().cos();
+            flow_y += sector.length * sector.angle.grade_angle().sin();
             total_magnitude += sector.length;
         }
 
@@ -1078,8 +1078,8 @@ fn it_measures_economic_sectoral_balance() {
     let duration = start.elapsed();
 
     // compute domestic sector balance (households + businesses)
-    let weighted_angle = (household_sector.angle.mod_4_angle() * household_sector.length
-        + business_sector.angle.mod_4_angle() * business_sector.length)
+    let weighted_angle = (household_sector.angle.grade_angle() * household_sector.length
+        + business_sector.angle.grade_angle() * business_sector.length)
         / (household_sector.length + business_sector.length);
     let domestic_private_balance = Geonum::new(
         household_sector.length + business_sector.length,
@@ -1098,13 +1098,13 @@ fn it_measures_economic_sectoral_balance() {
 
     // sectoral balance identity: domestic private + public + foreign = 0
     // in angles, this means they should sum to approximate zero when weighted by magnitude
-    let _total_weighted_angle = domestic_private_balance.angle.mod_4_angle()
+    let _total_weighted_angle = domestic_private_balance.angle.grade_angle()
         * domestic_private_balance.length
-        + public_balance.angle.mod_4_angle() * public_balance.length
-        + foreign_balance.angle.mod_4_angle() * foreign_balance.length;
+        + public_balance.angle.grade_angle() * public_balance.length
+        + foreign_balance.angle.grade_angle() * foreign_balance.length;
 
     // detect economic imbalances through angle analysis
-    let imbalance_detected = economic_balance.angle.mod_4_angle().abs() > 0.1;
+    let imbalance_detected = economic_balance.angle.grade_angle().abs() > 0.1;
 
     println!(
         "Economic balance analysis: {:.2} nanoseconds",
@@ -1113,7 +1113,7 @@ fn it_measures_economic_sectoral_balance() {
     println!("Detected imbalance: {imbalance_detected}");
     println!(
         "Economy net angle: {:.4}",
-        economic_balance.angle.mod_4_angle()
+        economic_balance.angle.grade_angle()
     );
 
     // demonstrate how this analysis would detect economic crises early through

--- a/tests/em_field_theory_test.rs
+++ b/tests/em_field_theory_test.rs
@@ -110,7 +110,7 @@ fn its_a_maxwell_equation() {
     let db_dt = Geonum::new_with_blade(
         2.0,
         2, // bivector (grade 2) - time derivative of a bivector field remains bivector
-        b_field.angle.mod_4_angle(),
+        b_field.angle.grade_angle(),
         PI,
     ); // preserves the geometric algebra grade of the original field
 
@@ -163,7 +163,7 @@ fn its_a_maxwell_equation() {
     assert!(adjusted_curl_b.length_diff(&mu_epsilon_de_dt) < 0.1);
     assert!(
         (adjusted_curl_b.angle - mu_epsilon_de_dt.angle)
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             < EPSILON
     );
@@ -328,8 +328,8 @@ fn its_an_electromagnetic_wave() {
     let b_time2 = b_field.propagate(time2, position, speed_of_light);
 
     // relative phase between E and B should remain constant (90 degrees)
-    let eb_phase_diff1 = (e_time1.angle - b_time1.angle).mod_4_angle();
-    let eb_phase_diff2 = (e_time2.angle - b_time2.angle).mod_4_angle();
+    let eb_phase_diff1 = (e_time1.angle - b_time1.angle).grade_angle();
+    let eb_phase_diff2 = (e_time2.angle - b_time2.angle).grade_angle();
     assert!(
         (eb_phase_diff1 - eb_phase_diff2).abs() < EPSILON,
         "E-B phase difference should remain constant"
@@ -545,7 +545,7 @@ fn its_a_poynting_vector() {
     // each grade level represents π/2 rotation, so 3 levels = 3π/2
     // they're different grades separated by 3 levels of π/2 rotations
     // 3π/2 is still perpendicular - it just doesn't ignore the blade accumulation
-    let angle_diff_es = (s_poynting.angle - e_field.angle).mod_4_angle();
+    let angle_diff_es = (s_poynting.angle - e_field.angle).grade_angle();
     let expected_es_diff = 3.0 * PI / 2.0; // 270 degrees
 
     assert!(
@@ -570,11 +570,11 @@ fn its_a_poynting_vector() {
     // traditional calculation would use cross product and vector algebra
     let traditional_poynting = |e: &Geonum, b: &Geonum| -> Geonum {
         // convert to cartesian for cross product
-        let e_x = e.length * e.angle.mod_4_angle().cos();
-        let e_y = e.length * e.angle.mod_4_angle().sin();
+        let e_x = e.length * e.angle.grade_angle().cos();
+        let e_y = e.length * e.angle.grade_angle().sin();
 
-        let b_x = b.length * b.angle.mod_4_angle().cos();
-        let b_y = b.length * b.angle.mod_4_angle().sin();
+        let b_x = b.length * b.angle.grade_angle().cos();
+        let b_y = b.length * b.angle.grade_angle().sin();
 
         // cross product in 3D (assuming E, B in xy-plane, S points in z)
         let s_z = (e_x * b_y - e_y * b_x) / VACUUM_PERMEABILITY;
@@ -644,7 +644,7 @@ fn its_a_poynting_vector() {
     let s_incident = Geonum::new_with_blade(
         incident_wedge.length / VACUUM_PERMEABILITY,
         3, // trivector (grade 3) - Poynting vector is a trivector (grade 1 + grade 2 = grade 3)
-        incident_wedge.angle.mod_4_angle(),
+        incident_wedge.angle.grade_angle(),
         PI,
     ); // represents energy flow as oriented volume element
 
@@ -652,7 +652,7 @@ fn its_a_poynting_vector() {
     let s_reflected = Geonum::new_with_blade(
         reflected_wedge.length / VACUUM_PERMEABILITY,
         3, // trivector (grade 3) - Poynting vector is a trivector (grade 1 + grade 2 = grade 3)
-        reflected_wedge.angle.mod_4_angle(),
+        reflected_wedge.angle.grade_angle(),
         PI,
     ); // represents energy flow as oriented volume element for reflected wave
 
@@ -675,7 +675,7 @@ fn its_a_poynting_vector() {
     let s_transmitted = Geonum::new_with_blade(
         transmitted_wedge.length / VACUUM_PERMEABILITY,
         3, // trivector (grade 3) - Poynting vector is a trivector (grade 1 + grade 2 = grade 3)
-        transmitted_wedge.angle.mod_4_angle(),
+        transmitted_wedge.angle.grade_angle(),
         PI,
     ); // represents energy flow as oriented volume element for transmitted wave
 
@@ -689,7 +689,7 @@ fn its_a_poynting_vector() {
     // test direction of energy flow (reflected is opposite to incident)
     // For S-vectors, the PI rotation might be represented differently
     // so we check that the angle difference is close to PI in either direction
-    let angle_diff = (s_reflected.angle - s_incident.angle).mod_4_angle();
+    let angle_diff = (s_reflected.angle - s_incident.angle).grade_angle();
     assert!(
         (angle_diff - PI).abs() < EPSILON || (angle_diff - 0.0).abs() < EPSILON,
         "Reflected flow should be opposite to incident"
@@ -885,7 +885,7 @@ fn its_a_field_potential() {
     let curl_a = Geonum::new_with_blade(
         a_potential_r.length / test_radius_b, // radial derivative component
         2, // bivector (grade 2) - curl of vector potential produces magnetic field bivector
-        a_potential_r.differentiate().angle.mod_4_angle(),
+        a_potential_r.differentiate().angle.grade_angle(),
         PI,
     ); // in geometric algebra, curl operation on vector raises grade by 1
 
@@ -917,11 +917,11 @@ fn its_a_field_potential() {
 
         // A' = A + ∇λ
         // convert both to cartesian, add, convert back to geometric
-        let a_x = a.length * a.angle.mod_4_angle().cos();
-        let a_y = a.length * a.angle.mod_4_angle().sin();
+        let a_x = a.length * a.angle.grade_angle().cos();
+        let a_y = a.length * a.angle.grade_angle().sin();
 
-        let grad_x = grad_lambda.length * grad_lambda.angle.mod_4_angle().cos();
-        let grad_y = grad_lambda.length * grad_lambda.angle.mod_4_angle().sin();
+        let grad_x = grad_lambda.length * grad_lambda.angle.grade_angle().cos();
+        let grad_y = grad_lambda.length * grad_lambda.angle.grade_angle().sin();
 
         let new_a_x = a_x + grad_x;
         let new_a_y = a_y + grad_y;
@@ -986,7 +986,7 @@ fn its_a_field_potential() {
         "original b field at r={}: length={}, angle={}",
         test_radius_b,
         b_original.length,
-        b_original.angle.mod_4_angle()
+        b_original.angle.grade_angle()
     );
     println!("gauge invariance proves b field remains unchanged when a -> a + ∇λ");
 
@@ -1067,12 +1067,12 @@ fn it_creates_electric_field() {
 
     // verify field direction
     assert_eq!(
-        positive_field.angle.mod_4_angle(),
+        positive_field.angle.grade_angle(),
         PI,
         "Positive charge field points outward"
     );
     assert_eq!(
-        negative_field.angle.mod_4_angle(),
+        negative_field.angle.grade_angle(),
         0.0,
         "Negative charge field points inward"
     );
@@ -1114,7 +1114,7 @@ fn it_computes_poynting_vector() {
 
     // verify direction (perpendicular to both E and B)
     assert!(
-        (poynting.angle.mod_4_angle() - PI).abs() < 1e-10,
+        (poynting.angle.grade_angle() - PI).abs() < 1e-10,
         "Poynting vector points perpendicular to both fields"
     );
 
@@ -1151,7 +1151,7 @@ fn it_models_wire_magnetic_field() {
 
     // direction around the wire
     assert_eq!(
-        b_field.angle.mod_4_angle(),
+        b_field.angle.grade_angle(),
         0.0,
         "Magnetic field circles the wire"
     );

--- a/tests/fem_test.rs
+++ b/tests/fem_test.rs
@@ -53,7 +53,7 @@ fn its_a_shape_function() {
     // validate derivative at a point
     let deriv_at_half = shape_derivative(0.5);
     assert_eq!(deriv_at_half.length, 1.0);
-    assert_eq!(deriv_at_half.angle.mod_4_angle(), PI);
+    assert_eq!(deriv_at_half.angle.grade_angle(), PI);
 
     // demonstrate ability to represent high-order shape functions
     // using a composition of simple angle operations
@@ -140,7 +140,7 @@ fn its_a_stiffness_matrix() {
 
     // test force equals k*x for spring (k=1)
     assert_eq!(force.length, 0.5);
-    assert_eq!(force.angle.mod_4_angle(), 0.0);
+    assert_eq!(force.angle.grade_angle(), 0.0);
 
     // demonstrate boundary condition application through angle constraints
     // with BCs, displacements are constrained in traditional FEM by modifying
@@ -177,7 +177,7 @@ fn its_a_stiffness_matrix() {
 
     // test the stress computation
     assert!((stress.length - 1.0).abs() < EPSILON);
-    assert!((stress.angle.mod_4_angle() - (PI / 4.0 + PI / 6.0)).abs() < EPSILON);
+    assert!((stress.angle.grade_angle() - (PI / 4.0 + PI / 6.0)).abs() < EPSILON);
 
     // demonstrate how a million-element assembly maintains O(1) complexity
     // with geonum's angle representation

--- a/tests/geocollection_test.rs
+++ b/tests/geocollection_test.rs
@@ -109,7 +109,7 @@ fn it_handles_scanning_laser_beams() {
     // compute angular coverage
     let mut angles: Vec<f64> = laser_beams
         .iter()
-        .map(|beam| beam.angle.mod_4_angle())
+        .map(|beam| beam.angle.grade_angle())
         .collect();
     angles.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
@@ -229,8 +229,8 @@ fn it_represents_electromagnetic_field_lines() {
 
     for i in 0..field_lines.len() {
         for j in (i + 1)..field_lines.len() {
-            let angle1 = field_lines[i].angle.mod_4_angle();
-            let angle2 = field_lines[j].angle.mod_4_angle();
+            let angle1 = field_lines[i].angle.grade_angle();
+            let angle2 = field_lines[j].angle.grade_angle();
             let separation = (angle2 - angle1).abs();
             angular_separations.push(separation);
         }
@@ -286,7 +286,7 @@ fn it_demonstrates_why_single_geonum_fails_here() {
     // Result: angles have been added together
     // Original: 0°, 90°, 45°
     // Combined: 0° + 90° + 45° = 135°
-    assert_eq!(combined_wrong.angle.mod_4_angle(), 3.0 * PI / 4.0);
+    assert_eq!(combined_wrong.angle.grade_angle(), 3.0 * PI / 4.0);
 
     // We've lost the fact that these were three separate beams!
     // The combined result suggests one beam at 135°, not three beams at different angles
@@ -305,9 +305,9 @@ fn it_demonstrates_why_single_geonum_fails_here() {
 
     // With separate representation, we can:
     // 1. Query individual beam properties
-    assert_eq!(separate_beams[0].angle.mod_4_angle(), 0.0);
-    assert_eq!(separate_beams[1].angle.mod_4_angle(), PI / 2.0);
-    assert_eq!(separate_beams[2].angle.mod_4_angle(), PI / 4.0);
+    assert_eq!(separate_beams[0].angle.grade_angle(), 0.0);
+    assert_eq!(separate_beams[1].angle.grade_angle(), PI / 2.0);
+    assert_eq!(separate_beams[2].angle.grade_angle(), PI / 4.0);
 
     // 2. Compute pairwise interactions
     let beam1_beam2_meet = separate_beams[0].meet(&separate_beams[1]);

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -15,8 +15,8 @@ fn it_adds_scalars() {
     let b = Geonum::new_with_blade(4.0, 0, 0.0, 1.0); // [4, 0] = positive 4, scalar
 
     // convert to cartesian (for scalars, just the length)
-    let a_cartesian = a.length * a.angle.mod_4_angle().cos(); // 3
-    let b_cartesian = b.length * b.angle.mod_4_angle().cos(); // 4
+    let a_cartesian = a.length * a.angle.grade_angle().cos(); // 3
+    let b_cartesian = b.length * b.angle.grade_angle().cos(); // 4
 
     // add them
     let sum_cartesian = a_cartesian + b_cartesian; // 7
@@ -39,8 +39,8 @@ fn it_adds_scalars() {
     let d = Geonum::new_with_blade(8.0, 0, 1.0, 1.0); // [8, pi] = negative 8, scalar
 
     // convert to cartesian for operation
-    let c_cartesian = c.length * c.angle.mod_4_angle().cos(); // 5
-    let d_cartesian = d.length * d.angle.mod_4_angle().cos(); // -8
+    let c_cartesian = c.length * c.angle.grade_angle().cos(); // 5
+    let d_cartesian = d.length * d.angle.grade_angle().cos(); // -8
 
     // add them
     let difference = c_cartesian + d_cartesian; // -3
@@ -110,11 +110,11 @@ fn it_adds_vectors() {
     let b = Geonum::new_with_blade(4.0, 1, 1.0, 2.0); // [4, pi/2] = 4 along y-axis, vector
 
     // convert to cartesian coordinates
-    let a_x = a.length * a.angle.mod_4_angle().cos(); // 3
-    let a_y = a.length * a.angle.mod_4_angle().sin(); // 0
+    let a_x = a.length * a.angle.grade_angle().cos(); // 3
+    let a_y = a.length * a.angle.grade_angle().sin(); // 0
 
-    let b_x = b.length * b.angle.mod_4_angle().cos(); // 0
-    let b_y = b.length * b.angle.mod_4_angle().sin(); // 4
+    let b_x = b.length * b.angle.grade_angle().cos(); // 0
+    let b_y = b.length * b.angle.grade_angle().sin(); // 4
 
     // add the components
     let sum_x = a_x + b_x; // 3
@@ -141,11 +141,11 @@ fn it_adds_vectors() {
     let d = Geonum::new_with_blade(5.0, 1, 1.0, 1.0); // [5, pi] = 5 along negative x-axis, vector
 
     // convert to cartesian
-    let c_x = c.length * c.angle.mod_4_angle().cos(); // 5
-    let c_y = c.length * c.angle.mod_4_angle().sin(); // 0
+    let c_x = c.length * c.angle.grade_angle().cos(); // 5
+    let c_y = c.length * c.angle.grade_angle().sin(); // 0
 
-    let d_x = d.length * d.angle.mod_4_angle().cos(); // -5
-    let d_y = d.length * d.angle.mod_4_angle().sin(); // 0
+    let d_x = d.length * d.angle.grade_angle().cos(); // -5
+    let d_y = d.length * d.angle.grade_angle().sin(); // 0
 
     // add components
     let sum2_x = c_x + d_x; // 0

--- a/tests/linear_algebra_test.rs
+++ b/tests/linear_algebra_test.rs
@@ -57,9 +57,9 @@ fn it_proves_decomposing_angles_with_linearly_combined_basis_vectors_loses_angle
         "  {} + {} = {}",
         theta1,
         theta2,
-        product.angle.mod_4_angle()
+        product.angle.grade_angle()
     );
-    assert!((product.angle.mod_4_angle() - expected_sum).abs() < EPSILON);
+    assert!((product.angle.grade_angle() - expected_sum).abs() < EPSILON);
     assert_eq!(product.angle, g1.angle + g2.angle);
 
     // THE UNADDED ANGLES
@@ -225,7 +225,7 @@ fn it_proves_decomposing_angles_into_scalar_coefficients_makes_angle_a_multivari
         "  Geonum: {} + {} = {}",
         angle,
         rotation_angle,
-        rotated_geometric.angle.mod_4_angle()
+        rotated_geometric.angle.grade_angle()
     );
 
     // decomposition: must update both coefficients using rotation formulas
@@ -271,9 +271,9 @@ fn it_proves_decomposing_angles_into_scalar_coefficients_makes_angle_a_multivari
         "  Geonum gives: {} + {} = {}",
         v1_angle,
         v2_angle,
-        product.angle.mod_4_angle()
+        product.angle.grade_angle()
     );
-    assert!((product.angle.mod_4_angle() - (v1_angle + v2_angle)).abs() < EPSILON);
+    assert!((product.angle.grade_angle() - (v1_angle + v2_angle)).abs() < EPSILON);
 
     // SIDE EFFECT 5: Constraints between coefficients
     // for unit vectors: c₁² + c₂² = 1 must be maintained
@@ -376,12 +376,12 @@ fn it_proves_linear_combination_forces_angle_through_coefficient_algebra() {
         "  Add: {} + {} = {}",
         angle1,
         angle2,
-        (g1 * g2).angle.mod_4_angle()
+        (g1 * g2).angle.grade_angle()
     );
     println!(
         "  Double: {} * 2 = {}",
         angle1,
-        (g1 * g1).angle.mod_4_angle()
+        (g1 * g1).angle.grade_angle()
     );
     println!("  No coefficient algebra needed!");
 }
@@ -499,18 +499,18 @@ fn it_proves_angle_becomes_implicit_ratio_between_components() {
     // geonum: angle is first-class, not a ratio ghost
     let g = Geonum::new(r, theta, PI);
     println!("\ngeonum keeps angle explicit:");
-    println!("  angle = {} (directly stored)", g.angle.mod_4_angle());
+    println!("  angle = {} (directly stored)", g.angle.grade_angle());
     println!("  not computed from ratios");
     println!("  not scattered across components");
     println!("  not dependent on basis choice");
 
     // rotation is just angle addition: O(1) always
     let g_rotated = g.rotate(Angle::new(rotation, PI));
-    assert!((g_rotated.angle.mod_4_angle() - (theta + rotation)).abs() < EPSILON);
+    assert!((g_rotated.angle.grade_angle() - (theta + rotation)).abs() < EPSILON);
     println!(
         "  rotation: {} + {} = {} (direct addition)",
         theta,
         rotation,
-        g_rotated.angle.mod_4_angle()
+        g_rotated.angle.grade_angle()
     );
 }

--- a/tests/machine_learning_test.rs
+++ b/tests/machine_learning_test.rs
@@ -48,8 +48,8 @@ fn its_a_perceptron() {
     let x_neg = Geonum::new(1.0, 5.0, 4.0); // Vector (grade 1) - input vector (negative example)
 
     // demonstrate that dot product can be computed via lengths and angles
-    let dot_pos = w.length * x_pos.length * (w.angle - x_pos.angle).mod_4_angle().cos();
-    let dot_neg = w.length * x_neg.length * (w.angle - x_neg.angle).mod_4_angle().cos();
+    let dot_pos = w.length * x_pos.length * (w.angle - x_pos.angle).grade_angle().cos();
+    let dot_neg = w.length * x_neg.length * (w.angle - x_neg.angle).grade_angle().cos();
 
     assert!(dot_pos > 0.0, "positive example misclassified");
     assert!(dot_neg < 0.0, "negative example misclassified");
@@ -73,9 +73,9 @@ fn its_a_perceptron() {
     // after updates, both classify x_neg
     let dot_traditional = w_traditional.length
         * x_neg.length
-        * (w_traditional.angle - x_neg.angle).mod_4_angle().cos();
+        * (w_traditional.angle - x_neg.angle).grade_angle().cos();
     let dot_geometric =
-        w_geometric.length * x_neg.length * (w_geometric.angle - x_neg.angle).mod_4_angle().cos();
+        w_geometric.length * x_neg.length * (w_geometric.angle - x_neg.angle).grade_angle().cos();
 
     // both methods improve classification (larger negative value is worse)
     assert!(
@@ -131,7 +131,7 @@ fn its_a_linear_regression() {
 
     // verify our geometric representation can recover the regression parameters
     // the slope is encoded in the angle: tan(θ) = slope
-    let slope_geometric = regression_geo.angle.mod_4_angle().tan();
+    let slope_geometric = regression_geo.angle.grade_angle().tan();
 
     // the regression line parameters will match
     assert!(
@@ -229,14 +229,14 @@ fn its_a_decision_tree() {
     // with geometric numbers, we can use angle variance
 
     // compute angle variance for each class
-    let mean_angle_a = (class_a[0].angle.mod_4_angle() + class_a[1].angle.mod_4_angle()) / 2.0;
-    let var_angle_a = ((class_a[0].angle.mod_4_angle() - mean_angle_a).powi(2)
-        + (class_a[1].angle.mod_4_angle() - mean_angle_a).powi(2))
+    let mean_angle_a = (class_a[0].angle.grade_angle() + class_a[1].angle.grade_angle()) / 2.0;
+    let var_angle_a = ((class_a[0].angle.grade_angle() - mean_angle_a).powi(2)
+        + (class_a[1].angle.grade_angle() - mean_angle_a).powi(2))
         / 2.0;
 
-    let mean_angle_b = (class_b[0].angle.mod_4_angle() + class_b[1].angle.mod_4_angle()) / 2.0;
-    let var_angle_b = ((class_b[0].angle.mod_4_angle() - mean_angle_b).powi(2)
-        + (class_b[1].angle.mod_4_angle() - mean_angle_b).powi(2))
+    let mean_angle_b = (class_b[0].angle.grade_angle() + class_b[1].angle.grade_angle()) / 2.0;
+    let var_angle_b = ((class_b[0].angle.grade_angle() - mean_angle_b).powi(2)
+        + (class_b[1].angle.grade_angle() - mean_angle_b).powi(2))
         / 2.0;
 
     // low variance indicates pure classes
@@ -258,12 +258,12 @@ fn its_a_decision_tree() {
     let test_point_b = Geonum::new(1.0, PI + 0.2, PI);
 
     // classify based on angle comparison (constant time operation)
-    let prediction_a = if test_point_a.angle.mod_4_angle() < split_angle {
+    let prediction_a = if test_point_a.angle.grade_angle() < split_angle {
         "A"
     } else {
         "B"
     };
-    let prediction_b = if test_point_b.angle.mod_4_angle() < split_angle {
+    let prediction_b = if test_point_b.angle.grade_angle() < split_angle {
         "A"
     } else {
         "B"
@@ -321,7 +321,7 @@ fn its_a_support_vector_machine() {
     // the angle that maximizes the margin between classes
 
     // a simple approach: angle halfway between the closest points
-    let margin_angle = (class_a[1].angle.mod_4_angle() + class_b[1].angle.mod_4_angle()) / 2.0;
+    let margin_angle = (class_a[1].angle.grade_angle() + class_b[1].angle.grade_angle()) / 2.0;
 
     // 3. demonstrate hyperplane as angle boundary rather than vector normal
 
@@ -329,12 +329,12 @@ fn its_a_support_vector_machine() {
     let test_point_a = Geonum::new(1.0, 0.25, PI);
     let test_point_b = Geonum::new(1.0, PI - 0.25, PI);
 
-    let prediction_a = if test_point_a.angle.mod_4_angle() < margin_angle {
+    let prediction_a = if test_point_a.angle.grade_angle() < margin_angle {
         1
     } else {
         -1
     };
-    let prediction_b = if test_point_b.angle.mod_4_angle() < margin_angle {
+    let prediction_b = if test_point_b.angle.grade_angle() < margin_angle {
         1
     } else {
         -1
@@ -567,7 +567,7 @@ fn its_a_dimensionality_reduction() {
             // projection as geometric operation
             // for simplicity, use the component along principal direction
             let dot_product =
-                p.length * principal.length * (p.angle - principal.angle).mod_4_angle().cos();
+                p.length * principal.length * (p.angle - principal.angle).grade_angle().cos();
             let projection_scalar = Geonum::new(dot_product / principal.length.powi(2), 0.0, 1.0);
             principal * projection_scalar
         })
@@ -1035,7 +1035,7 @@ fn it_scales_quantum_learning() {
             .iter()
             .map(|g| {
                 let dot_product =
-                    g.length * point.length * (g.angle - point.angle).mod_4_angle().cos();
+                    g.length * point.length * (g.angle - point.angle).grade_angle().cos();
                 (g, dot_product)
             })
             .max_by(|(_, d1), (_, d2)| d1.partial_cmp(d2).unwrap())

--- a/tests/mechanics_test.rs
+++ b/tests/mechanics_test.rs
@@ -204,7 +204,7 @@ fn it_encodes_position() {
     );
     assert_eq!(position.length, 3.0, "distance from origin");
     assert!(
-        (position.angle.mod_4_angle() - PI / 4.0).abs() < EPSILON,
+        (position.angle.grade_angle() - PI / 4.0).abs() < EPSILON,
         "direction angle π/4"
     );
 
@@ -213,8 +213,10 @@ fn it_encodes_position() {
     let new_position = position + displacement;
 
     // verify geometric addition produces expected result
-    let (x1, y1) = position.to_cartesian();
-    let (x2, y2) = displacement.to_cartesian();
+    let x1 = position.length * position.angle.grade_angle().cos();
+    let y1 = position.length * position.angle.grade_angle().sin();
+    let x2 = displacement.length * displacement.angle.grade_angle().cos();
+    let y2 = displacement.length * displacement.angle.grade_angle().sin();
     let expected_length = ((x1 + x2).powi(2) + (y1 + y2).powi(2)).sqrt();
     assert!(
         (new_position.length - expected_length).abs() < EPSILON,
@@ -307,7 +309,7 @@ fn it_encodes_velocity() {
 
     // angle matches after base_angle reset
     assert!(
-        (position_base.angle.mod_4_angle() - initial_position.angle.mod_4_angle()).abs() < EPSILON,
+        (position_base.angle.grade_angle() - initial_position.angle.grade_angle()).abs() < EPSILON,
         "integration recovers original angle"
     );
 
@@ -416,7 +418,7 @@ fn it_displaces_from_derived_velocity() {
     println!(
         "initial position: length={}, angle={}, blade={}",
         initial_position.length,
-        initial_position.angle.mod_4_angle(),
+        initial_position.angle.grade_angle(),
         initial_position.angle.blade()
     );
 
@@ -430,7 +432,7 @@ fn it_displaces_from_derived_velocity() {
     println!(
         "derived velocity: length={}, angle={}, blade={}",
         velocity.length,
-        velocity.angle.mod_4_angle(),
+        velocity.angle.grade_angle(),
         velocity.angle.blade()
     );
 
@@ -445,7 +447,7 @@ fn it_displaces_from_derived_velocity() {
     println!(
         "displacement: length={}, angle={}, blade={}",
         displacement.length,
-        displacement.angle.mod_4_angle(),
+        displacement.angle.grade_angle(),
         displacement.angle.blade()
     );
 
@@ -454,7 +456,7 @@ fn it_displaces_from_derived_velocity() {
     println!(
         "final position: length={}, angle={}, blade={}",
         final_position.length,
-        final_position.angle.mod_4_angle(),
+        final_position.angle.grade_angle(),
         final_position.angle.blade()
     );
 
@@ -463,9 +465,12 @@ fn it_displaces_from_derived_velocity() {
     // displacement: 20m at π/3 + π/2 = 5π/6 (150°)
 
     // convert to cartesian to verify physics
-    let (x0, y0) = initial_position.to_cartesian();
-    let (dx, dy) = displacement.to_cartesian();
-    let (xf, yf) = final_position.to_cartesian();
+    let x0 = initial_position.length * initial_position.angle.grade_angle().cos();
+    let y0 = initial_position.length * initial_position.angle.grade_angle().sin();
+    let dx = displacement.length * displacement.angle.grade_angle().cos();
+    let dy = displacement.length * displacement.angle.grade_angle().sin();
+    let xf = final_position.length * final_position.angle.grade_angle().cos();
+    let yf = final_position.length * final_position.angle.grade_angle().sin();
 
     println!("\ncartesian verification:");
     println!("  initial: ({:.3}, {:.3})", x0, y0);
@@ -505,7 +510,7 @@ fn it_displaces_from_derived_velocity() {
 
     // angle difference between original and perpendicular: 5π/6 - π/3 = π/2
     let angle_diff =
-        (perpendicular_position.angle.mod_4_angle() - initial_position.angle.mod_4_angle()).abs();
+        (perpendicular_position.angle.grade_angle() - initial_position.angle.grade_angle()).abs();
     assert!(
         (angle_diff - PI / 2.0).abs() < EPSILON,
         "positions are perpendicular"
@@ -513,7 +518,7 @@ fn it_displaces_from_derived_velocity() {
 
     // their derived velocities should also be perpendicular
     let velocity_angle_diff =
-        (perpendicular_velocity.angle.mod_4_angle() - velocity.angle.mod_4_angle()).abs();
+        (perpendicular_velocity.angle.grade_angle() - velocity.angle.grade_angle()).abs();
     let normalized_diff = if velocity_angle_diff > PI {
         2.0 * PI - velocity_angle_diff
     } else {
@@ -543,7 +548,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "initial position: length={}, angle={}, blade={}",
         initial_position.length,
-        initial_position.angle.mod_4_angle(),
+        initial_position.angle.grade_angle(),
         initial_position.angle.blade()
     );
 
@@ -553,7 +558,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "initial velocity: length={}, angle={}, blade={}",
         initial_velocity.length,
-        initial_velocity.angle.mod_4_angle(),
+        initial_velocity.angle.grade_angle(),
         initial_velocity.angle.blade()
     );
 
@@ -567,7 +572,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "acceleration: length={}, angle={}, blade={}",
         acceleration.length,
-        acceleration.angle.mod_4_angle(),
+        acceleration.angle.grade_angle(),
         acceleration.angle.blade()
     );
 
@@ -584,7 +589,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "\nlinear displacement (v₀t): length={}, angle={}",
         linear_displacement.length,
-        linear_displacement.angle.mod_4_angle()
+        linear_displacement.angle.grade_angle()
     );
 
     // second term: ½at² (quadratic displacement from acceleration)
@@ -601,7 +606,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "quadratic displacement (½at²): length={}, angle={}",
         quadratic_displacement.length,
-        quadratic_displacement.angle.mod_4_angle()
+        quadratic_displacement.angle.grade_angle()
     );
 
     // total displacement: combine linear and quadratic terms
@@ -609,7 +614,7 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "total displacement: length={}, angle={}, blade={}",
         total_displacement.length,
-        total_displacement.angle.mod_4_angle(),
+        total_displacement.angle.grade_angle(),
         total_displacement.angle.blade()
     );
 
@@ -618,15 +623,19 @@ fn it_squares_displacement_from_derived_acceleration() {
     println!(
         "final position: length={}, angle={}, blade={}",
         final_position.length,
-        final_position.angle.mod_4_angle(),
+        final_position.angle.grade_angle(),
         final_position.angle.blade()
     );
 
     // verify physics in cartesian coordinates
-    let (x0, y0) = initial_position.to_cartesian();
-    let (dx_linear, dy_linear) = linear_displacement.to_cartesian();
-    let (dx_quad, dy_quad) = quadratic_displacement.to_cartesian();
-    let (xf, yf) = final_position.to_cartesian();
+    let x0 = initial_position.length * initial_position.angle.grade_angle().cos();
+    let y0 = initial_position.length * initial_position.angle.grade_angle().sin();
+    let dx_linear = linear_displacement.length * linear_displacement.angle.grade_angle().cos();
+    let dy_linear = linear_displacement.length * linear_displacement.angle.grade_angle().sin();
+    let dx_quad = quadratic_displacement.length * quadratic_displacement.angle.grade_angle().cos();
+    let dy_quad = quadratic_displacement.length * quadratic_displacement.angle.grade_angle().sin();
+    let xf = final_position.length * final_position.angle.grade_angle().cos();
+    let yf = final_position.length * final_position.angle.grade_angle().sin();
 
     println!("\ncartesian verification:");
     println!("  initial: ({:.3}, {:.3})", x0, y0);
@@ -836,7 +845,7 @@ fn it_encodes_angular_momentum() {
     assert_eq!(angular_momentum.angle.grade(), 2, "L at grade 2 (bivector)");
 
     // magnitude encodes |r||p|sin(θ)
-    let angle_diff = (momentum.angle - position.angle).mod_4_angle();
+    let angle_diff = (momentum.angle - position.angle).grade_angle();
     let expected_magnitude = position.length * momentum.length * angle_diff.sin().abs();
     assert!(
         (angular_momentum.length - expected_magnitude).abs() < EPSILON,
@@ -862,7 +871,7 @@ fn it_encodes_angular_momentum() {
     );
 
     // torque magnitude |r||F||sin(θ)|
-    let torque_angle_diff = (force.angle - position.angle).mod_4_angle();
+    let torque_angle_diff = (force.angle - position.angle).grade_angle();
     let expected_torque = position.length * force.length * torque_angle_diff.sin().abs();
     assert!(
         (torque.length - expected_torque).abs() < EPSILON,
@@ -1121,8 +1130,8 @@ fn it_encodes_potential_energy() {
     );
 
     // compute angle difference for expected value
-    let pos_angle = high_position.angle.mod_4_angle();
-    let field_angle = high_field.angle.mod_4_angle();
+    let pos_angle = high_position.angle.grade_angle();
+    let field_angle = high_field.angle.grade_angle();
     let angle_diff = (field_angle - pos_angle).abs();
     let cos_angle = angle_diff.cos();
 
@@ -1311,7 +1320,7 @@ fn it_encodes_torque() {
     // blade 1 force is at π/3 + π/2 = 5π/6
     // angle difference: 5π/6 - π/6 = 2π/3
     let angle_diff = force.angle - position.angle;
-    let expected_torque = 2.0 * 10.0 * angle_diff.mod_4_angle().sin().abs();
+    let expected_torque = 2.0 * 10.0 * angle_diff.grade_angle().sin().abs();
     assert!(
         (torque.length - expected_torque).abs() < EPSILON,
         "τ = r×F×sin(2π/3) ≈ 17.3 N·m"
@@ -1326,7 +1335,7 @@ fn it_encodes_torque() {
     let max_torque = position.wedge(&perpendicular_force);
 
     let max_angle_diff = perpendicular_force.angle - position.angle;
-    let expected_max = 2.0 * perpendicular_force.length * max_angle_diff.mod_4_angle().sin().abs();
+    let expected_max = 2.0 * perpendicular_force.length * max_angle_diff.grade_angle().sin().abs();
     assert!(
         (max_torque.length - expected_max).abs() < EPSILON,
         "perpendicular τ = {:.1} N·m",
@@ -1365,7 +1374,7 @@ fn it_encodes_torque() {
 
     // compute expected magnitude
     let high_angle_diff = high_force.angle - high_position.angle;
-    let expected_high = 3.0 * 8.0 * high_angle_diff.mod_4_angle().sin().abs();
+    let expected_high = 3.0 * 8.0 * high_angle_diff.grade_angle().sin().abs();
 
     assert!(
         (high_torque.length - expected_high).abs() < EPSILON,
@@ -1449,7 +1458,7 @@ fn it_encodes_angular_velocity() {
 
     // compute expected magnitude
     let angle_diff = high_radius.angle - high_omega.angle;
-    let expected_speed = 1.5 * 4.0 * angle_diff.mod_4_angle().sin().abs();
+    let expected_speed = 1.5 * 4.0 * angle_diff.grade_angle().sin().abs();
 
     assert!(
         (high_linear.length - expected_speed).abs() < EPSILON,
@@ -1869,7 +1878,7 @@ fn it_handles_energy_conservation() {
     let max_angle = Angle::new(1.0, 3.0); // π/3 radians (60°)
 
     // at maximum displacement: all PE, no KE
-    let max_height = pendulum_length * (1.0 - max_angle.mod_4_angle().cos()); // h = L(1 - cos θ)
+    let max_height = pendulum_length * (1.0 - max_angle.grade_angle().cos()); // h = L(1 - cos θ)
     let pe_max = mass * g * max_height;
 
     // at bottom: all KE, no PE (taking bottom as h=0)

--- a/tests/monetary_policy_test.rs
+++ b/tests/monetary_policy_test.rs
@@ -195,8 +195,8 @@ fn it_models_causal_transaction_structure() {
         }
 
         // weighted average of angles
-        let acc_angle = acc.angle.mod_4_angle();
-        let biv_angle = bivector.angle.mod_4_angle();
+        let acc_angle = acc.angle.grade_angle();
+        let biv_angle = bivector.angle.grade_angle();
         let new_angle = if acc.length > 0.0 {
             (acc_angle * acc.length + biv_angle * bivector.length) / new_length
         } else {
@@ -232,8 +232,8 @@ fn it_models_causal_transaction_structure() {
             return acc;
         }
 
-        let acc_angle = acc.angle.mod_4_angle();
-        let biv_angle = bivector.angle.mod_4_angle();
+        let acc_angle = acc.angle.grade_angle();
+        let biv_angle = bivector.angle.grade_angle();
         let new_angle = if acc.length > 0.0 {
             (acc_angle * acc.length + biv_angle * bivector.length) / new_length
         } else {
@@ -257,7 +257,7 @@ fn it_models_causal_transaction_structure() {
     );
     println!(
         "transaction net flow angle: {:.4}",
-        economic_flow.angle.mod_4_angle()
+        economic_flow.angle.grade_angle()
     );
     println!("conservation check: {total_balance:.10}");
 }
@@ -344,14 +344,14 @@ fn it_models_investment_network_resilience() {
         // compute directional impact
         let avg_angle_before = original
             .iter()
-            .map(|b| b.angle.mod_4_angle() * b.length)
+            .map(|b| b.angle.grade_angle() * b.length)
             .sum::<f64>()
             / initial_value;
 
         let avg_angle_after = after_default
             .iter()
             .filter(|b| b.length > 0.0) // exclude defaulted entities
-            .map(|b| b.angle.mod_4_angle() * b.length)
+            .map(|b| b.angle.grade_angle() * b.length)
             .sum::<f64>()
             / final_value;
 
@@ -384,7 +384,7 @@ fn it_models_investment_network_resilience() {
     println!("network loss: {:.2}%", impact.length * 100.0);
     println!(
         "investment direction shift: {:.4}",
-        impact.angle.mod_4_angle()
+        impact.angle.grade_angle()
     );
     println!("computation time: {:.2} nanoseconds", duration.as_nanos());
 
@@ -485,7 +485,7 @@ fn it_measures_the_cost_of_capital_without_a_federal_reserve_board() {
             // calculate mean angle (risk level)
             let _mean_angle = profit_rates
                 .iter()
-                .map(|g| g.angle.mod_4_angle())
+                .map(|g| g.angle.grade_angle())
                 .sum::<f64>()
                 / profit_rates.len() as f64;
 

--- a/tests/motion_laws_test.rs
+++ b/tests/motion_laws_test.rs
@@ -25,12 +25,12 @@ fn it_ships_conservation_with_the_wedge_product() {
     println!(
         "Vector: [{}, {:.3}]",
         vector.length,
-        vector.angle.mod_4_angle()
+        vector.angle.grade_angle()
     );
     println!(
         "v ∧ v = [{:.10}, {:.3}]",
         self_wedge.length,
-        self_wedge.angle.mod_4_angle()
+        self_wedge.angle.grade_angle()
     );
 
     // This IS conservation: you can't create something from nothing
@@ -70,17 +70,17 @@ fn it_ships_conservation_with_motion() {
     println!(
         "Position: [{:.2e}, {:.3}]",
         position.length,
-        position.angle.mod_4_angle()
+        position.angle.grade_angle()
     );
     println!(
         "Momentum: [{:.2e}, {:.3}]",
         momentum.length,
-        momentum.angle.mod_4_angle()
+        momentum.angle.grade_angle()
     );
     println!(
         "Angular momentum: [{:.3e}, {:.3}]",
         initial_angular_momentum.length,
-        initial_angular_momentum.angle.mod_4_angle()
+        initial_angular_momentum.angle.grade_angle()
     );
     println!("Energy: {:.3e}", initial_energy.length);
 
@@ -106,17 +106,17 @@ fn it_ships_conservation_with_motion() {
     println!(
         "Position: [{:.2e}, {:.3}]",
         position.length,
-        position.angle.mod_4_angle()
+        position.angle.grade_angle()
     );
     println!(
         "Momentum: [{:.2e}, {:.3}]",
         momentum.length,
-        momentum.angle.mod_4_angle()
+        momentum.angle.grade_angle()
     );
     println!(
         "Angular momentum: [{:.3e}, {:.3}]",
         final_angular_momentum.length,
-        final_angular_momentum.angle.mod_4_angle()
+        final_angular_momentum.angle.grade_angle()
     );
     println!("Energy: {:.3e}", final_energy.length);
 
@@ -171,12 +171,12 @@ fn it_sets_geometric_nilpotency_as_physical_law() {
         println!(
             "Quantity: [{:.3e}, {:.3}]",
             quantity.length,
-            quantity.angle.mod_4_angle()
+            quantity.angle.grade_angle()
         );
         println!(
             "Self-interaction: [{:.3e}, {:.3}]",
             self_interaction.length,
-            self_interaction.angle.mod_4_angle()
+            self_interaction.angle.grade_angle()
         );
 
         // Physical law: identical quantities cannot interact with themselves
@@ -216,12 +216,12 @@ fn its_independent_of_external_enforcement() {
     println!(
         "Vector: [{}, {:.3}]",
         vector.length,
-        vector.angle.mod_4_angle()
+        vector.angle.grade_angle()
     );
     println!(
         "Self-wedge: [{:.10}, {:.3}]",
         attempted_violation.length,
-        attempted_violation.angle.mod_4_angle()
+        attempted_violation.angle.grade_angle()
     );
 
     // Violation impossible - algebra prevents it
@@ -258,7 +258,7 @@ fn its_independent_of_external_enforcement() {
             "Violation attempt {}: [{:.10}, {:.3}]",
             i + 1,
             violation_attempt.length,
-            violation_attempt.angle.mod_4_angle()
+            violation_attempt.angle.grade_angle()
         );
         assert!(
             violation_attempt.length < EPSILON,
@@ -295,7 +295,7 @@ fn it_unifies_newtons_disparate_laws_into_one_operation() {
     println!(
         "   Self-wedge = [{:.10}, {:.3}]",
         inertia_test.length,
-        inertia_test.angle.mod_4_angle()
+        inertia_test.angle.grade_angle()
     );
 
     // Newton's "Second Law" = Just the geometric product
@@ -327,16 +327,16 @@ fn it_unifies_newtons_disparate_laws_into_one_operation() {
     println!(
         "   v∧w = [{:.3}, {:.3}]",
         action.length,
-        action.angle.mod_4_angle()
+        action.angle.grade_angle()
     );
     println!(
         "   w∧v = [{:.3}, {:.3}]",
         reaction.length,
-        reaction.angle.mod_4_angle()
+        reaction.angle.grade_angle()
     );
 
     // Prove antisymmetry (action = -reaction)
-    let angle_diff = (action.angle - reaction.angle).mod_4_angle().abs();
+    let angle_diff = (action.angle - reaction.angle).grade_angle().abs();
     let angle_diff_mod = angle_diff % (2.0 * PI);
     let is_opposite = (angle_diff_mod - PI).abs() < 0.1 || angle_diff_mod < 0.1;
     assert!(is_opposite, "Action and reaction are opposite");
@@ -426,7 +426,7 @@ fn it_improves_physics_engines() {
     println!(
         "Result: [{:.10}, {:.3}] - conservation proven",
         conservation_proof.length,
-        conservation_proof.angle.mod_4_angle()
+        conservation_proof.angle.grade_angle()
     );
 
     assert!(

--- a/tests/numbers_test.rs
+++ b/tests/numbers_test.rs
@@ -14,7 +14,7 @@ fn its_a_scalar() {
 
     // test if scalar has expected properties
     assert_eq!(scalar.length, 1.0);
-    assert_eq!(scalar.angle.mod_4_angle(), 0.0);
+    assert_eq!(scalar.angle.grade_angle(), 0.0);
 
     // multiplying scalars follows "angles add, lengths multiply" rule
     let scalar2 = Geonum::new(2.0, 0.0, 1.0);
@@ -23,7 +23,7 @@ fn its_a_scalar() {
 
     // 1 × 2 = 2
     assert_eq!(product.length, 2.0);
-    assert_eq!(product.angle.mod_4_angle(), 0.0);
+    assert_eq!(product.angle.grade_angle(), 0.0);
 
     // multiplication with negative scalar
     let neg_scalar = Geonum::new(3.0, 1.0, 1.0); // PI radians
@@ -32,7 +32,7 @@ fn its_a_scalar() {
 
     // 1 × (-3) = -3
     assert_eq!(neg_product.length, 3.0);
-    assert_eq!(neg_product.angle.mod_4_angle(), PI);
+    assert_eq!(neg_product.angle.grade_angle(), PI);
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn its_an_imaginary_number() {
     let rot4 = imaginary * rot3; // rotate four times
 
     assert_eq!(rot4.length, real.length);
-    assert!(rot4.angle.mod_4_angle().abs() < EPSILON); // back to original angle
+    assert!(rot4.angle.grade_angle().abs() < EPSILON); // back to original angle
 }
 
 #[test]
@@ -167,8 +167,8 @@ fn its_a_complex_number() {
     let one = Geonum::new(1.0, 0.0, 1.0); // scalar unit
 
     // in cartesian: -1 + 1 = 0
-    let result_cartesian = e_i_pi.length * e_i_pi.angle.mod_4_angle().cos()
-        + one.length * one.angle.mod_4_angle().cos();
+    let result_cartesian = e_i_pi.length * e_i_pi.angle.grade_angle().cos()
+        + one.length * one.angle.grade_angle().cos();
 
     assert!(result_cartesian.abs() < EPSILON); // test value is close to zero
 }
@@ -196,7 +196,7 @@ fn its_a_quaternion() {
     // the angles might be congruent mod 2π
     // the angles might be congruent mod 2π
     let expected_angle = Angle::new(1.0, 2.0); // π/2
-    let angle_diff = (jk.angle.mod_4_angle() - expected_angle.mod_4_angle()).abs();
+    let angle_diff = (jk.angle.grade_angle() - expected_angle.grade_angle()).abs();
     assert!(angle_diff < EPSILON || (TAU - angle_diff) < EPSILON);
 
     // test k*i = j
@@ -254,7 +254,7 @@ fn its_a_dual_number() {
     // ε² should map back to scalar (blade 0 or 4)
     assert_eq!(epsilon_squared.length, 1.0);
     // angle doubles: π + π = 2π ≡ 0 (mod 2π)
-    let angle_mod = epsilon_squared.angle.mod_4_angle();
+    let angle_mod = epsilon_squared.angle.grade_angle();
     assert!(
         angle_mod < EPSILON || (TAU - angle_mod) < EPSILON,
         "ε² returns to scalar"
@@ -386,7 +386,7 @@ fn its_an_octonion() {
     // test that they're not equal (non-associative)
     // test if lengths or angles differ
     let _equal = (e1e2e4.length - e1e2e4_alt.length).abs() < EPSILON
-        && (e1e2e4.angle.mod_4_angle() - e1e2e4_alt.angle.mod_4_angle()).abs() < EPSILON;
+        && (e1e2e4.angle.grade_angle() - e1e2e4_alt.angle.grade_angle()).abs() < EPSILON;
 
     // if they're not exactly equal, non-associativity is demonstrated
     // note: in this simplification, the actual values depend on how
@@ -710,15 +710,15 @@ fn it_dualizes_log2_geometric_algebra_components() {
     // we can extract grade-specific components to demonstrate this
 
     // extract grade 0 (scalar part)
-    let scalar = g.length * g.angle.mod_4_angle().cos();
+    let scalar = g.length * g.angle.grade_angle().cos();
 
     // extract grade 1 (vector part, magnitude)
-    let vector_magnitude = g.length * g.angle.mod_4_angle().sin();
+    let vector_magnitude = g.length * g.angle.grade_angle().sin();
 
     // extract grade 2 (bivector part)
     // in 2D GA, bivector represents rotation in the e1^e2 plane
     // which is encoded in the angle component
-    let bivector_angle = g.angle.mod_4_angle();
+    let bivector_angle = g.angle.grade_angle();
 
     // demonstrate that all grades of the 2D geometric algebra are encoded
     // in just the 2 components (length and angle) of the geometric number
@@ -765,8 +765,8 @@ fn it_keeps_information_entropy_zero() {
     // but for a perfect dualization, this equals 0 (no information is lost)
 
     // reconstruct original data from both geonums
-    let original_data = (g1.length, g1.angle.mod_4_angle());
-    let dual_data = (g2.length, g2.angle.mod_4_angle() - PI / 2.0);
+    let original_data = (g1.length, g1.angle.grade_angle());
+    let dual_data = (g2.length, g2.angle.grade_angle() - PI / 2.0);
 
     // compute difference (represents information loss if any)
     let length_diff = (original_data.0 - dual_data.0).abs();
@@ -802,7 +802,7 @@ fn its_a_bernoulli_number() {
     let b0_value = b0.length; // 1
     let b1_value = b1.length; // 0.5
     let b2_value = b2.length; // ≈ 0.1667
-    let b4_value = b4.length * b4.angle.mod_4_angle().cos(); // division result projected to scalar
+    let b4_value = b4.length * b4.angle.grade_angle().cos(); // division result projected to scalar
 
     // test the computed values
     assert_eq!(b0_value, 1.0);
@@ -1117,7 +1117,7 @@ fn its_a_eulers_identity() {
 
     // Test that e^(iπ) × e^(iπ) = 1 (multiplicative identity)
     assert_eq!(self_product.length, 1.0);
-    assert!(self_product.angle.mod_4_angle().abs() < EPSILON); // 2π ≡ 0 (mod 2π)
+    assert!(self_product.angle.grade_angle().abs() < EPSILON); // 2π ≡ 0 (mod 2π)
 
     // STEP 6: This is what Euler's identity actually demonstrates
     // Not mysterious connections between constants, but that [1, π]
@@ -1135,8 +1135,8 @@ fn its_a_eulers_identity() {
     let one = Geonum::new(1.0, 0.0, 1.0); // [1, 0] = pointing forwards = +1
 
     // Verify they're additive inverses (opposite directions, same magnitude)
-    let cartesian_sum = e_to_ipi.length * e_to_ipi.angle.mod_4_angle().cos()
-        + one.length * one.angle.mod_4_angle().cos();
+    let cartesian_sum = e_to_ipi.length * e_to_ipi.angle.grade_angle().cos()
+        + one.length * one.angle.grade_angle().cos();
     assert!(cartesian_sum.abs() < EPSILON);
 
     // STEP 8: The complete picture
@@ -1165,7 +1165,7 @@ fn its_a_eulers_identity() {
 
     // 2π ≡ 0 (mod 2π), so we're back to [1, 0] = multiplicative identity
     assert_eq!(twice_rotated.length, 1.0);
-    assert!(twice_rotated.angle.mod_4_angle().abs() < EPSILON);
+    assert!(twice_rotated.angle.grade_angle().abs() < EPSILON);
 
     // CONCLUSION: Euler's identity reveals fundamental geometric inverse properties
 

--- a/tests/optics_test.rs
+++ b/tests/optics_test.rs
@@ -77,7 +77,7 @@ fn its_a_wavefront() {
     let interference = wave1 + wave2;
     let expected_constructive = (wave1.length.powi(2)
         + wave2.length.powi(2)
-        + 2.0 * wave1.length * wave2.length * (wave2.angle - wave1.angle).mod_4_angle().cos())
+        + 2.0 * wave1.length * wave2.length * (wave2.angle - wave1.angle).grade_angle().cos())
     .sqrt();
     let constructive_diff = (interference.length - expected_constructive).abs();
     assert!(constructive_diff < EPSILON); // interference follows I = √(A₁² + A₂² + 2A₁A₂cos(φ₁-φ₂))
@@ -116,18 +116,18 @@ fn its_a_polarizer() {
 
     // Malus law through angle difference: I = I₀cos²(θ₁-θ₂)
     let angle_diff = incident.angle - polarizer.angle; // π/6 - π/4 = -π/12
-    let cos_squared = angle_diff.mod_4_angle().cos().powi(2);
+    let cos_squared = angle_diff.grade_angle().cos().powi(2);
     let expected_intensity = incident.length * cos_squared;
 
     // cross-polarizer test: 90° difference gives zero transmission
     let cross_polarizer = incident.rotate(Angle::new(1.0, 2.0)); // +π/2 rotation
     let cross_diff = incident.angle - cross_polarizer.angle; // π/2 difference
-    let cross_transmission = cross_diff.mod_4_angle().cos().powi(2);
+    let cross_transmission = cross_diff.grade_angle().cos().powi(2);
     assert!(cross_transmission < EPSILON); // cos²(π/2) = 0
 
     // parallel polarizer: 0° difference gives full transmission
     let parallel_diff = incident.angle - incident.angle; // 0 difference
-    let parallel_transmission = parallel_diff.mod_4_angle().cos().powi(2);
+    let parallel_transmission = parallel_diff.grade_angle().cos().powi(2);
     assert_eq!(parallel_transmission, 1.0); // cos²(0) = 1
 
     // verify expected intensity calculation
@@ -151,7 +151,7 @@ fn it_demonstrates_wave_interference_without_trigonometry() {
     let interference = wave1 + wave2;
     let expected_constructive = (wave1.length.powi(2)
         + wave2.length.powi(2)
-        + 2.0 * wave1.length * wave2.length * (wave2.angle - wave1.angle).mod_4_angle().cos())
+        + 2.0 * wave1.length * wave2.length * (wave2.angle - wave1.angle).grade_angle().cos())
     .sqrt();
     let constructive_diff = (interference.length - expected_constructive).abs();
     assert!(constructive_diff < EPSILON); // interference follows I = √(A₁² + A₂² + 2A₁A₂cos(φ₁-φ₂))
@@ -254,7 +254,7 @@ fn its_an_interferometer() {
     // verify interference formula emerges from geometric addition
     let traditional_intensity = (beam1.length.powi(2)
         + beam2.length.powi(2)
-        + 2.0 * beam1.length * beam2.length * (beam1.angle - beam2.angle).mod_4_angle().cos())
+        + 2.0 * beam1.length * beam2.length * (beam1.angle - beam2.angle).grade_angle().cos())
     .sqrt();
     let intensity_diff = (interference.length - traditional_intensity).abs();
     assert!(intensity_diff < EPSILON); // cosine terms emerge from angle arithmetic
@@ -319,7 +319,7 @@ fn its_a_prism() {
 
     // Snell's law as closure: eliminates trigonometric solving
     let snells_law = |ray: &Geonum, n1: f64, n2: f64| -> Geonum {
-        let incident_sin = ray.angle.mod_4_angle().sin();
+        let incident_sin = ray.angle.grade_angle().sin();
         let refracted_sin = incident_sin * n1 / n2;
         let refracted_angle = refracted_sin.asin();
         Geonum::new(ray.length, refracted_angle, PI)
@@ -707,7 +707,7 @@ fn its_lens_design_optimization() {
     println!(
         "initial system: error={:.3}, optical_angle={:.6} rad",
         lens_system.length,
-        lens_system.angle.mod_4_angle()
+        lens_system.angle.grade_angle()
     );
 
     // automatic differentiation: get exact sensitivity direction
@@ -717,7 +717,7 @@ fn its_lens_design_optimization() {
     println!(
         "gradient direction: magnitude={:.6}, angle={:.6} rad",
         gradient.length,
-        gradient.angle.mod_4_angle()
+        gradient.angle.grade_angle()
     );
 
     // optimization step: use gradient to compute correction direction
@@ -731,7 +731,7 @@ fn its_lens_design_optimization() {
     println!(
         "optimized system: error={:.6}, optical_angle={:.6} rad",
         optimized_system.length,
-        optimized_system.angle.mod_4_angle()
+        optimized_system.angle.grade_angle()
     );
 
     // verify optimization reduces error (length represents error magnitude)
@@ -753,7 +753,7 @@ fn its_lens_design_optimization() {
     println!(
         "compound system: error={:.6}, combined_power={:.6}",
         compound_system.length,
-        compound_system.angle.mod_4_angle()
+        compound_system.angle.grade_angle()
     );
 
     // system-level gradient: automatic differentiation of composed system

--- a/tests/qm_test.rs
+++ b/tests/qm_test.rs
@@ -50,7 +50,7 @@ fn its_a_state_vector() {
 
     // test direct geometric representation
     assert_eq!(state.length, 1.0); // normalized amplitude
-    assert!((state.angle.mod_4_angle() - PI / 4.0).abs() < EPSILON); // phase π/4
+    assert!((state.angle.grade_angle() - PI / 4.0).abs() < EPSILON); // phase π/4
 
     // superposition |ψ⟩ = α|0⟩ + β|1⟩ as single geonum from cartesian
     // equal probability superposition: (|0⟩ + |1⟩)/√2
@@ -68,11 +68,11 @@ fn its_a_state_vector() {
 
     // probability through born rule: |⟨ψ|basis⟩|² = cos²(angle_diff)
     let angle_diff0 = state.angle - basis0.angle;
-    let prob0 = state.length.powi(2) * angle_diff0.mod_4_angle().cos().powi(2);
+    let prob0 = state.length.powi(2) * angle_diff0.grade_angle().cos().powi(2);
     assert!((prob0 - 0.5).abs() < EPSILON); // cos²(π/4) = 0.5
 
     let angle_diff1 = state.angle - basis1.angle;
-    let prob1 = state.length.powi(2) * angle_diff1.mod_4_angle().cos().powi(2);
+    let prob1 = state.length.powi(2) * angle_diff1.grade_angle().cos().powi(2);
     assert!((prob1 - 0.5).abs() < EPSILON); // cos²(π/4 - π/2) = cos²(-π/4) = 0.5
 
     // total probability
@@ -81,11 +81,11 @@ fn its_a_state_vector() {
     // measurement alignment - no mysterious "collapse", just angle alignment
     let measurement_result = if prob0 > 0.5 { basis0 } else { basis1 };
     let alignment_check = (measurement_result.angle - basis0.angle)
-        .mod_4_angle()
+        .grade_angle()
         .abs()
         < EPSILON
         || (measurement_result.angle - basis1.angle)
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             < EPSILON;
     assert!(alignment_check);
@@ -170,7 +170,7 @@ fn its_a_spin_system() {
     // test spin-1/2 as minimal angle subdivision
     // in spin-1/2 systems, angles are separated by π
     let angle_diff = spin_down.angle - spin_up.angle;
-    assert_eq!(angle_diff.mod_4_angle(), PI);
+    assert_eq!(angle_diff.grade_angle(), PI);
 
     // test spin composition through direct rotation
     // measure spin-up in x-basis
@@ -187,7 +187,7 @@ fn its_a_spin_system() {
     // for a state at angle 0, measuring along pi/2 gives probability cos²(0 - pi/2) = cos²(-pi/2) = 0
     let measurement_angle = Angle::new(1.0, 2.0); // π/2
     let angle_difference = spin_up.angle - measurement_angle;
-    let prob_up_x = spin_up.length * spin_up.length * angle_difference.mod_4_angle().cos().powi(2);
+    let prob_up_x = spin_up.length * spin_up.length * angle_difference.grade_angle().cos().powi(2);
     assert!(prob_up_x < EPSILON); // equals 0 probability
 }
 
@@ -251,7 +251,7 @@ fn its_a_quantum_gate() {
     //     [0 i]
     let phase_gate = |q: &Geonum| -> Geonum {
         // check if in |1⟩ state (angle π/2)
-        let angle_mod = q.angle.mod_4_angle();
+        let angle_mod = q.angle.grade_angle();
         if (angle_mod - PI / 2.0).abs() < EPSILON {
             // if in the |1⟩ state, add π/2 to the angle
             q.rotate(Angle::new(1.0, 2.0))
@@ -264,7 +264,7 @@ fn its_a_quantum_gate() {
     // test gate application through angle transformation
     let h_applied = hadamard(&qubit);
     assert_eq!(h_applied.length, qubit.length); // preserves norm
-    assert!((h_applied.angle.mod_4_angle() - PI / 4.0).abs() < EPSILON); // creates superposition
+    assert!((h_applied.angle.grade_angle() - PI / 4.0).abs() < EPSILON); // creates superposition
 
     // test gate composition through angle addition
     // first apply hadamard, then phase gate
@@ -293,7 +293,7 @@ fn its_a_quantum_measurement() {
     // test measurement as angle correlation
     // probability of measuring in basis0 = |⟨0|ψ⟩|²
     let angle_diff0 = state.angle - basis0.angle;
-    let prob_basis0 = state.length * state.length * angle_diff0.mod_4_angle().cos().powi(2);
+    let prob_basis0 = state.length * state.length * angle_diff0.grade_angle().cos().powi(2);
 
     // test born rule through angle projection instead of abstract inner product
     assert!((0.0..=1.0).contains(&prob_basis0));
@@ -302,7 +302,7 @@ fn its_a_quantum_measurement() {
 
     // probability of measuring in basis1
     let angle_diff1 = state.angle - basis1.angle;
-    let prob_basis1 = state.length * state.length * angle_diff1.mod_4_angle().cos().powi(2);
+    let prob_basis1 = state.length * state.length * angle_diff1.grade_angle().cos().powi(2);
     assert!((0.0..=1.0).contains(&prob_basis1));
     // for a state at pi/4, the probability relative to pi/2 is cos²(pi/4 - pi/2) = cos²(-pi/4) = 0.5
     assert!((prob_basis1 - 0.5).abs() < EPSILON);
@@ -322,8 +322,8 @@ fn its_a_quantum_measurement() {
     };
 
     // test the measured state is aligned with one of the basis states
-    let angle_to_basis0 = (measured_state.angle - basis0.angle).mod_4_angle();
-    let angle_to_basis1 = (measured_state.angle - basis1.angle).mod_4_angle();
+    let angle_to_basis0 = (measured_state.angle - basis0.angle).grade_angle();
+    let angle_to_basis1 = (measured_state.angle - basis1.angle).grade_angle();
     assert!(angle_to_basis0.abs() < EPSILON || angle_to_basis1.abs() < EPSILON);
 }
 
@@ -342,7 +342,7 @@ fn its_an_entangled_state() {
     // test entanglement as angle relationship
     // the angles are precisely correlated
     let angle_diff = bell_state.1.angle - bell_state.0.angle;
-    assert_eq!(angle_diff.mod_4_angle(), PI);
+    assert_eq!(angle_diff.grade_angle(), PI);
 
     // test bell state properties through angle configuration
     assert!((bell_state.0.length - 1.0 / 2.0_f64.sqrt()).abs() < EPSILON);
@@ -355,7 +355,7 @@ fn its_an_entangled_state() {
     let first_measurement = Angle::new(0.0, 1.0); // measured in |0⟩ state
 
     // test second particles state is determined by first measurement
-    let angle_match_0 = (first_measurement - bell_state.0.angle).mod_4_angle().abs() < EPSILON;
+    let angle_match_0 = (first_measurement - bell_state.0.angle).grade_angle().abs() < EPSILON;
     let second_particle_angle = if angle_match_0 {
         bell_state.0.angle // |0⟩ for second particle
     } else {
@@ -367,7 +367,7 @@ fn its_an_entangled_state() {
 
     // test nonlocality naturally emerges from angle correlation
     // no need for abstract "spooky action" - just geometric correspondence
-    let correlation_diff = (first_measurement - second_particle_angle).mod_4_angle();
+    let correlation_diff = (first_measurement - second_particle_angle).grade_angle();
     assert!(correlation_diff.abs() < EPSILON);
 }
 
@@ -388,8 +388,8 @@ fn its_a_quantum_harmonic_oscillator() {
     let energy_diff2 = second_excited.angle - first_excited.angle;
 
     // both differences should be π/2
-    assert_eq!(energy_diff1.mod_4_angle(), PI / 2.0);
-    assert_eq!(energy_diff2.mod_4_angle(), PI / 2.0);
+    assert_eq!(energy_diff1.grade_angle(), PI / 2.0);
+    assert_eq!(energy_diff2.grade_angle(), PI / 2.0);
 
     // create ladder operators as angle shifts
     // a† (creation) raises energy level, a (annihilation) lowers it
@@ -490,8 +490,8 @@ fn its_a_path_integral() {
     let mut sum_x = 0.0;
     let mut sum_y = 0.0;
     for path in &paths {
-        sum_x += path.length * path.angle.mod_4_angle().cos();
-        sum_y += path.length * path.angle.mod_4_angle().sin();
+        sum_x += path.length * path.angle.grade_angle().cos();
+        sum_y += path.length * path.angle.grade_angle().sin();
     }
 
     // convert back to geometric number
@@ -602,11 +602,11 @@ fn its_a_quantum_information_system() {
     // compute statistical dispersion of angles
     let angle_dispersion: f64 = mixed_state
         .iter()
-        .map(|(p, g)| p * g.angle.mod_4_angle().powi(2))
+        .map(|(p, g)| p * g.angle.grade_angle().powi(2))
         .sum::<f64>()
         - mixed_state
             .iter()
-            .map(|(p, g)| p * g.angle.mod_4_angle())
+            .map(|(p, g)| p * g.angle.grade_angle())
             .sum::<f64>()
             .powi(2);
 
@@ -617,7 +617,7 @@ fn its_a_quantum_information_system() {
     // a quantum channel can be represented as a transformation
     let channel = |state: &Geonum| -> Geonum {
         // depolarizing channel: potentially rotate the state
-        if state.angle.mod_4_angle().abs() < EPSILON {
+        if state.angle.grade_angle().abs() < EPSILON {
             // leave 70% probability unchanged, rotate 30%
             Geonum::new_with_angle(state.length * 0.7_f64.sqrt(), state.angle)
         } else {
@@ -660,12 +660,12 @@ fn it_rejects_copenhagen_interpretation() {
     // test measurement as natural process, not mysterious collapse
     // probability of measuring in basis0
     let angle_diff0 = state.angle - basis0.angle;
-    let prob0 = state.length * state.length * angle_diff0.mod_4_angle().cos().powi(2);
+    let prob0 = state.length * state.length * angle_diff0.grade_angle().cos().powi(2);
     assert!((0.0..=1.0).contains(&prob0));
 
     // probability of measuring in basis1
     let angle_diff1 = state.angle - basis1.angle;
-    let prob1 = state.length * state.length * angle_diff1.mod_4_angle().cos().powi(2);
+    let prob1 = state.length * state.length * angle_diff1.grade_angle().cos().powi(2);
     assert!((0.0..=1.0).contains(&prob1));
 
     // test total probability = 1
@@ -763,12 +763,12 @@ fn it_unifies_quantum_and_classical() {
             let total_p: f64 = dist.iter().map(|(p, _)| p).sum();
             let mean_sin: f64 = dist
                 .iter()
-                .map(|(p, g)| p * g.angle.mod_4_angle().sin())
+                .map(|(p, g)| p * g.angle.grade_angle().sin())
                 .sum::<f64>()
                 / total_p;
             let mean_cos: f64 = dist
                 .iter()
-                .map(|(p, g)| p * g.angle.mod_4_angle().cos())
+                .map(|(p, g)| p * g.angle.grade_angle().cos())
                 .sum::<f64>()
                 / total_p;
             let mean_angle = Angle::new_from_cartesian(mean_cos, mean_sin);
@@ -776,7 +776,7 @@ fn it_unifies_quantum_and_classical() {
             // compute dispersion using angle differences
             dist.iter()
                 .map(|(p, g)| {
-                    let diff = (g.angle - mean_angle).mod_4_angle();
+                    let diff = (g.angle - mean_angle).grade_angle();
                     p * diff.powi(2)
                 })
                 .sum::<f64>()
@@ -797,20 +797,20 @@ fn it_unifies_quantum_and_classical() {
     let total_p: f64 = narrow_dist.iter().map(|(p, _)| p).sum();
     let exp_sin: f64 = narrow_dist
         .iter()
-        .map(|(p, g)| p * g.angle.mod_4_angle().sin())
+        .map(|(p, g)| p * g.angle.grade_angle().sin())
         .sum::<f64>()
         / total_p;
     let exp_cos: f64 = narrow_dist
         .iter()
-        .map(|(p, g)| p * g.angle.mod_4_angle().cos())
+        .map(|(p, g)| p * g.angle.grade_angle().cos())
         .sum::<f64>()
         / total_p;
     let exp_angle = Angle::new_from_cartesian(exp_cos, exp_sin);
 
     // test this equals a definite classical value (π/8)
     let classical_angle = Angle::new(1.0, 8.0);
-    assert!((exp_angle.mod_4_angle().sin() - classical_angle.mod_4_angle().sin()).abs() < 0.001);
-    assert!((exp_angle.mod_4_angle().cos() - classical_angle.mod_4_angle().cos()).abs() < 0.001);
+    assert!((exp_angle.grade_angle().sin() - classical_angle.grade_angle().sin()).abs() < 0.001);
+    assert!((exp_angle.grade_angle().cos() - classical_angle.grade_angle().cos()).abs() < 0.001);
 }
 
 #[test]
@@ -878,7 +878,7 @@ fn it_eliminates_statistical_collections() {
     assert_eq!(pure_state.length, 1.0); // normalized
                                         // phase is definite, not statistical
     let expected_phase = (0.8_f64).atan2(0.6);
-    assert!((pure_state.angle.mod_4_angle() - expected_phase).abs() < EPSILON);
+    assert!((pure_state.angle.grade_angle() - expected_phase).abs() < EPSILON);
 
     // measurement outcomes from projection geometry, not probability sampling
     let measurement_axis = Geonum::new(1.0, 0.0, 1.0); // |0⟩ basis

--- a/tests/robotics_test.rs
+++ b/tests/robotics_test.rs
@@ -220,8 +220,8 @@ fn its_a_redundant_manipulator() {
         cumulative3.value() < 1e-10,
         "bent config returns to 0 value"
     );
-    assert!(cumulative3.mod_4_angle().cos() > 0.999, "cos(2π) = 1");
-    assert!(cumulative3.mod_4_angle().sin().abs() < 1e-10, "sin(2π) = 0");
+    assert!(cumulative3.grade_angle().cos() > 0.999, "cos(2π) = 1");
+    assert!(cumulative3.grade_angle().sin().abs() < 1e-10, "sin(2π) = 0");
 
     // both solutions reach target
     let error_straight = target.distance_to(&end_straight);
@@ -234,7 +234,8 @@ fn its_a_redundant_manipulator() {
     );
 
     // bent config reaches different position
-    let (bent_x, bent_y) = end_bent.to_cartesian();
+    let bent_x = end_bent.adj().length;
+    let bent_y = end_bent.opp().length;
     assert!((bent_x - 4.464).abs() < 0.001, "bent config x position");
     assert!(bent_y.abs() < 0.001, "bent config y position (horizontal)");
 

--- a/tests/set_theory_test.rs
+++ b/tests/set_theory_test.rs
@@ -79,7 +79,7 @@ fn its_a_naive_set() {
     // test we measure relationships instead of asserting them
     // degree of intersection is measurable through angle
     let angle_diff = b.angle - a.angle; // π/2 difference
-    let correlation = a.length * b.length * angle_diff.mod_4_angle().cos().abs();
+    let correlation = a.length * b.length * angle_diff.grade_angle().cos().abs();
     assert!(correlation < EPSILON); // orthogonal = 0 correlation
 }
 
@@ -122,8 +122,8 @@ fn its_a_group() {
     let product = quarter_turn * inverse;
     // product is identity (angle 0)
     assert!(
-        product.angle.mod_4_angle() < EPSILON
-            || (TAU - product.angle.mod_4_angle()).abs() < EPSILON
+        product.angle.grade_angle() < EPSILON
+            || (TAU - product.angle.grade_angle()).abs() < EPSILON
     );
 }
 
@@ -142,12 +142,12 @@ fn its_a_ring() {
 
     // convert to cartesian to perform addition
     let b_cartesian = [
-        b.length * b.angle.mod_4_angle().cos(),
-        b.length * b.angle.mod_4_angle().sin(),
+        b.length * b.angle.grade_angle().cos(),
+        b.length * b.angle.grade_angle().sin(),
     ];
     let c_cartesian = [
-        c.length * c.angle.mod_4_angle().cos(),
-        c.length * c.angle.mod_4_angle().sin(),
+        c.length * c.angle.grade_angle().cos(),
+        c.length * c.angle.grade_angle().sin(),
     ];
 
     // b + c in cartesian
@@ -173,12 +173,12 @@ fn its_a_ring() {
 
     // convert to cartesian to add results
     let ab_cartesian = [
-        ab.length * ab.angle.mod_4_angle().cos(),
-        ab.length * ab.angle.mod_4_angle().sin(),
+        ab.length * ab.angle.grade_angle().cos(),
+        ab.length * ab.angle.grade_angle().sin(),
     ];
     let ac_cartesian = [
-        ac.length * ac.angle.mod_4_angle().cos(),
-        ac.length * ac.angle.mod_4_angle().sin(),
+        ac.length * ac.angle.grade_angle().cos(),
+        ac.length * ac.angle.grade_angle().sin(),
     ];
 
     // add results in cartesian
@@ -199,7 +199,7 @@ fn its_a_ring() {
     assert!((left_side.length - right_side.length).abs() < EPSILON);
 
     // angles might differ by 2π
-    let angle_diff = (left_side.angle - right_side.angle).mod_4_angle();
+    let angle_diff = (left_side.angle - right_side.angle).grade_angle();
     assert!(angle_diff.abs() < EPSILON || (TAU - angle_diff).abs() < EPSILON);
 
     // test commutativity as physical rotation invariance
@@ -291,9 +291,9 @@ fn its_a_vector_space() {
     // test angle-based addition
     // vector addition as component-wise operation in the same angle space
     let v_comp1 =
-        v[0].length * v[0].angle.mod_4_angle().cos() + w[0].length * w[0].angle.mod_4_angle().cos();
+        v[0].length * v[0].angle.grade_angle().cos() + w[0].length * w[0].angle.grade_angle().cos();
     let v_comp2 =
-        v[1].length * v[1].angle.mod_4_angle().sin() + w[1].length * w[1].angle.mod_4_angle().sin();
+        v[1].length * v[1].angle.grade_angle().sin() + w[1].length * w[1].angle.grade_angle().sin();
 
     // test sum is 4e1 + 6e2
     assert!((v_comp1 - 4.0).abs() < EPSILON);
@@ -396,7 +396,7 @@ fn its_a_lie_algebra() {
     assert!((a_wedge_b.length - b_wedge_a.length).abs() < EPSILON);
 
     // test angles differ by π (orientation flip)
-    let angle_diff = (a_wedge_b.angle - b_wedge_a.angle).mod_4_angle();
+    let angle_diff = (a_wedge_b.angle - b_wedge_a.angle).grade_angle();
     assert!((angle_diff - PI).abs() < EPSILON);
 
     // test Jacobi identity geometrically
@@ -416,12 +416,12 @@ fn its_a_lie_algebra() {
     let term3 = c.wedge(&ab);
 
     // convert to cartesian to sum
-    let term1_cartesian = term1.length * term1.angle.mod_4_angle().cos()
-        + term1.length * term1.angle.mod_4_angle().sin();
-    let term2_cartesian = term2.length * term2.angle.mod_4_angle().cos()
-        + term2.length * term2.angle.mod_4_angle().sin();
-    let term3_cartesian = term3.length * term3.angle.mod_4_angle().cos()
-        + term3.length * term3.angle.mod_4_angle().sin();
+    let term1_cartesian = term1.length * term1.angle.grade_angle().cos()
+        + term1.length * term1.angle.grade_angle().sin();
+    let term2_cartesian = term2.length * term2.angle.grade_angle().cos()
+        + term2.length * term2.angle.grade_angle().sin();
+    let term3_cartesian = term3.length * term3.angle.grade_angle().cos()
+        + term3.length * term3.angle.grade_angle().sin();
 
     // test sum approximately zero (demonstrates Jacobi identity geometrically)
     let sum = (term1_cartesian + term2_cartesian + term3_cartesian).abs();
@@ -536,7 +536,7 @@ fn its_a_metric_space() {
     // test distance via angle difference
     // define distance as minimum angle between points (on the circle)
     let d = |a: &Geonum, b: &Geonum| -> f64 {
-        let angle_diff = (a.angle - b.angle).mod_4_angle();
+        let angle_diff = (a.angle - b.angle).grade_angle();
         angle_diff.min(TAU - angle_diff)
     };
 
@@ -650,7 +650,7 @@ fn its_a_fiber_bundle() {
     // a section assigns one point in each fiber
     // define a section that maps angle θ to length sin(θ)+2
     let section =
-        |angle: Angle| -> Geonum { Geonum::new_with_angle(angle.mod_4_angle().sin() + 2.0, angle) };
+        |angle: Angle| -> Geonum { Geonum::new_with_angle(angle.grade_angle().sin() + 2.0, angle) };
 
     // test the section at different base points
     let s1 = section(Angle::new(0.0, 1.0));

--- a/tests/tensor_test.rs
+++ b/tests/tensor_test.rs
@@ -58,11 +58,11 @@ fn its_a_tensor_product() {
     // demonstrate distributivity: a ⊗ (b + c) = a ⊗ b + a ⊗ c using cartesian addition
 
     // create b + c in cartesian
-    let e2_x = e2.length * e2.angle.mod_4_angle().cos(); // 0
-    let e2_y = e2.length * e2.angle.mod_4_angle().sin(); // 1
+    let e2_x = e2.length * e2.angle.grade_angle().cos(); // 0
+    let e2_y = e2.length * e2.angle.grade_angle().sin(); // 1
 
-    let e3_x = e3.length * e3.angle.mod_4_angle().cos(); // -1
-    let e3_y = e3.length * e3.angle.mod_4_angle().sin(); // 0
+    let e3_x = e3.length * e3.angle.grade_angle().cos(); // -1
+    let e3_y = e3.length * e3.angle.grade_angle().sin(); // 0
 
     let sum_x = e2_x + e3_x; // -1
     let sum_y = e2_y + e3_y; // 1
@@ -85,11 +85,11 @@ fn its_a_tensor_product() {
     let a_tensor_c = e1.wedge(&e3); // a ⊗ c → bivector
 
     // convert a ⊗ b and a ⊗ c back to cartesian form for vector addition
-    let ab_x = a_tensor_b.length * a_tensor_b.angle.mod_4_angle().cos();
-    let ab_y = a_tensor_b.length * a_tensor_b.angle.mod_4_angle().sin();
+    let ab_x = a_tensor_b.length * a_tensor_b.angle.grade_angle().cos();
+    let ab_y = a_tensor_b.length * a_tensor_b.angle.grade_angle().sin();
 
-    let ac_x = a_tensor_c.length * a_tensor_c.angle.mod_4_angle().cos();
-    let ac_y = a_tensor_c.length * a_tensor_c.angle.mod_4_angle().sin();
+    let ac_x = a_tensor_c.length * a_tensor_c.angle.grade_angle().cos();
+    let ac_y = a_tensor_c.length * a_tensor_c.angle.grade_angle().sin();
 
     // perform vector addition of bivectors in the plane
     let sum_products_x = ab_x + ac_x;
@@ -105,7 +105,7 @@ fn its_a_tensor_product() {
     // prove that a ⊗ (b + c) and a ⊗ b + a ⊗ c differ in phase by 45° (π/4 radians)
     // geonum captures this additional structure — tensors do not
 
-    let angle_diff = (left_distribute.angle - Angle::new(sum_products_angle, PI)).mod_4_angle();
+    let angle_diff = (left_distribute.angle - Angle::new(sum_products_angle, PI)).grade_angle();
     assert!((angle_diff - PI / 4.0).abs() < EPSILON); // ≈ 0.785398...
 
     // demonstrate rank-3 tensor operation efficiency
@@ -161,7 +161,7 @@ fn its_a_tensor_product() {
 
     // in geonum ijk = [1, π/2 + π + 3π/2] = [1, 3π] = [1, π] = -1
     assert_eq!(ijk.length, 1.0);
-    assert!((ijk.angle.mod_4_angle() - PI).abs() < EPSILON);
+    assert!((ijk.angle.grade_angle() - PI).abs() < EPSILON);
 
     // compare with traditional tensor implementation
 
@@ -238,10 +238,10 @@ fn its_a_kronecker_product() {
 
     // traditional kronecker blocks A₁₁B₁₁, A₁₂B₁₁, etc:
     // geonum computes these exact same values through trigonometric projections
-    let expected_k00 = kronecker.length * (kronecker.angle.mod_4_angle() - 0.0).cos();
-    let expected_k01 = kronecker.length * (kronecker.angle.mod_4_angle() - PI / 2.0).cos();
-    let expected_k10 = kronecker.length * (kronecker.angle.mod_4_angle() - PI).cos();
-    let expected_k11 = kronecker.length * (kronecker.angle.mod_4_angle() - 3.0 * PI / 2.0).cos();
+    let expected_k00 = kronecker.length * (kronecker.angle.grade_angle() - 0.0).cos();
+    let expected_k01 = kronecker.length * (kronecker.angle.grade_angle() - PI / 2.0).cos();
+    let expected_k10 = kronecker.length * (kronecker.angle.grade_angle() - PI).cos();
+    let expected_k11 = kronecker.length * (kronecker.angle.grade_angle() - 3.0 * PI / 2.0).cos();
 
     assert!((k00_projection - expected_k00).abs() < EPSILON);
     assert!((k01_projection - expected_k01).abs() < EPSILON);
@@ -316,7 +316,7 @@ fn its_a_contraction() {
     let v1 = Geonum::new(2.0, 1.0, 4.0); // PI/4
     let v2 = Geonum::new(3.0, 1.0, 3.0); // PI/3
     let v1_dot_v2 = v1.dot(&v2);
-    let expected = 2.0 * 3.0 * (v1.angle - v2.angle).mod_4_angle().cos();
+    let expected = 2.0 * 3.0 * (v1.angle - v2.angle).grade_angle().cos();
 
     assert!((v1_dot_v2.length - expected).abs() < EPSILON);
 
@@ -406,7 +406,7 @@ fn its_a_covariant_derivative() {
 
     // prove covariant differs from ordinary due to curvature
     assert!(
-        (covariant_derivative.angle.mod_4_angle() - ordinary_derivative.angle.mod_4_angle()).abs()
+        (covariant_derivative.angle.grade_angle() - ordinary_derivative.angle.grade_angle()).abs()
             > EPSILON,
         "curvature modifies derivative through rotation"
     );
@@ -418,7 +418,7 @@ fn its_a_covariant_derivative() {
 
     // prove parallel transport changes orientation in curved space
     assert!(
-        (parallel_transported.angle.mod_4_angle() - initial_vector.angle.mod_4_angle()).abs()
+        (parallel_transported.angle.grade_angle() - initial_vector.angle.grade_angle()).abs()
             > EPSILON,
         "parallel transport rotates vector in curved space"
     );
@@ -447,7 +447,7 @@ fn its_a_covariant_derivative() {
 
     // prove geodesic deviation through angle change caused by differential curvature
     assert!(
-        (evolved_separation.angle.mod_4_angle() - separation_vector.angle.mod_4_angle()).abs()
+        (evolved_separation.angle.grade_angle() - separation_vector.angle.grade_angle()).abs()
             > EPSILON,
         "differential curvature rotates geodesic separation vector"
     );
@@ -475,7 +475,7 @@ fn its_a_covariant_derivative() {
 
     // holonomy: net rotation after completing the loop
     let holonomy_angle =
-        (transported_vector.angle.mod_4_angle() - test_vector.angle.mod_4_angle()).abs();
+        (transported_vector.angle.grade_angle() - test_vector.angle.grade_angle()).abs();
 
     // prove nonzero holonomy reveals spacetime curvature
     assert!(
@@ -716,7 +716,7 @@ fn its_a_quantum_tensor_network() {
 
     // expectation value with geonum
     let expectation = |state1: &Geonum, state2: &Geonum| -> f64 {
-        state1.length * state2.length * (state1.angle - state2.angle).mod_4_angle().cos()
+        state1.length * state2.length * (state1.angle - state2.angle).grade_angle().cos()
     };
 
     // compute expectation between neighbors
@@ -826,8 +826,8 @@ fn its_a_quantum_tensor_network() {
         // phase flip gate
         let pi_2 = Angle::new(1.0, 2.0); // PI/2
         let three_pi_2 = Angle::new(3.0, 2.0); // 3*PI/2
-        if (q.angle - pi_2).mod_4_angle().abs() < EPSILON
-            || (q.angle - three_pi_2).mod_4_angle().abs() < EPSILON
+        if (q.angle - pi_2).grade_angle().abs() < EPSILON
+            || (q.angle - three_pi_2).grade_angle().abs() < EPSILON
         {
             // apply -1 phase to |1⟩ component
             Geonum::new_with_angle(
@@ -860,8 +860,8 @@ fn its_a_quantum_tensor_network() {
         // apply phase only if control is |1⟩
         let pi = Angle::new(1.0, 1.0);
         let three_pi = Angle::new(3.0, 1.0);
-        if (control.angle - pi).mod_4_angle().abs() < EPSILON
-            || (control.angle - three_pi).mod_4_angle().abs() < EPSILON
+        if (control.angle - pi).grade_angle().abs() < EPSILON
+            || (control.angle - three_pi).grade_angle().abs() < EPSILON
         {
             (
                 *control,
@@ -1351,7 +1351,7 @@ fn its_a_multi_linear_map() {
     // verify that one-forms transform oppositely to vectors
     assert!(
         (one_form_transformed.angle - geo_transform.angle)
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             > 0.1
     );
@@ -1424,7 +1424,7 @@ fn its_a_multi_linear_map() {
     let two_form_reversed = e2.wedge(&e1);
     assert!(
         (two_form.angle - two_form_reversed.angle)
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             > PI - EPSILON
     );
@@ -1451,7 +1451,7 @@ fn its_a_multi_linear_map() {
     assert_eq!(pullback.length, two_form.length);
     assert!(
         (pullback.angle - (two_form.angle - Angle::new(theta, PI)))
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             < EPSILON
     );
@@ -1464,7 +1464,7 @@ fn its_a_multi_linear_map() {
         vector.length
             * two_form.length
             * (vector.angle - two_form.angle + Angle::new(1.0, 2.0))
-                .mod_4_angle()
+                .grade_angle()
                 .cos(),
         two_form.angle.blade() - 1,
         two_form.angle.value() + PI / 2.0,
@@ -1550,11 +1550,11 @@ fn its_a_multi_linear_map() {
     // they should have π/2 angle difference
     assert!(
         (ham_vector.angle - gradient.angle - Angle::new(1.0, 2.0))
-            .mod_4_angle()
+            .grade_angle()
             .abs()
             < EPSILON
             || (ham_vector.angle - gradient.angle + Angle::new(3.0, 2.0))
-                .mod_4_angle()
+                .grade_angle()
                 .abs()
                 < EPSILON
     );
@@ -1954,7 +1954,7 @@ fn its_a_tensor_comparison() {
         geo_vector = Geonum::new_with_blade(
             geo_vector.length,
             1,
-            (geo_vector.angle + Angle::new(0.001 * (i as f64).sin(), PI)).mod_4_angle(),
+            (geo_vector.angle + Angle::new(0.001 * (i as f64).sin(), PI)).grade_angle(),
             1.0,
         );
     }
@@ -2032,7 +2032,7 @@ fn its_a_metric_signature() {
 
     // 0 + 0 = 0, cos(0) = +1
     assert_eq!(e1_squared.angle.blade(), 0);
-    assert!(e1_squared.angle.mod_4_angle().cos() > 0.0); // positive signature
+    assert!(e1_squared.angle.grade_angle().cos() > 0.0); // positive signature
     assert_eq!(e1_squared.length, 1.0);
 
     // test 2: minkowski signature emerges from timelike at π/2
@@ -2044,7 +2044,7 @@ fn its_a_metric_signature() {
 
     // π/2 + π/2 = π, cos(π) = -1
     assert_eq!(time_squared.angle.blade(), 2); // blade 1 + 1 = 2 (which is π)
-    assert!(time_squared.angle.mod_4_angle().cos() < 0.0); // negative signature!
+    assert!(time_squared.angle.grade_angle().cos() < 0.0); // negative signature!
 
     // test 3: the "choice" of signature is just choosing initial angles
     // traditional: "lets use signature (+,-,-,+)"
@@ -2056,10 +2056,10 @@ fn its_a_metric_signature() {
     let custom_e3 = Geonum::new_with_blade(1.0, 0, 0.0, 1.0); // 0° → squares to +
 
     // verify the signature (+,-,-,+)
-    assert!((custom_e0 * custom_e0).angle.mod_4_angle().cos() > 0.0); // +
-    assert!((custom_e1 * custom_e1).angle.mod_4_angle().cos() < 0.0); // -
-    assert!((custom_e2 * custom_e2).angle.mod_4_angle().cos() < 0.0); // -
-    assert!((custom_e3 * custom_e3).angle.mod_4_angle().cos() > 0.0); // +
+    assert!((custom_e0 * custom_e0).angle.grade_angle().cos() > 0.0); // +
+    assert!((custom_e1 * custom_e1).angle.grade_angle().cos() < 0.0); // -
+    assert!((custom_e2 * custom_e2).angle.grade_angle().cos() < 0.0); // -
+    assert!((custom_e3 * custom_e3).angle.grade_angle().cos() > 0.0); // +
 
     // test 4: "negative" vectors squaring to positive
     // traditional: "in clifford algebras, some negative elements square to positive"
@@ -2069,8 +2069,8 @@ fn its_a_metric_signature() {
     let squared = negative_vector * negative_vector;
 
     // π + π = 2π, and 2π ≡ 0 (mod 2π)
-    assert!(squared.angle.mod_4_angle().abs() < 1e-10); // back to 0
-    assert!(squared.angle.mod_4_angle().cos() > 0.0); // positive result
+    assert!(squared.angle.grade_angle().abs() < 1e-10); // back to 0
+    assert!(squared.angle.grade_angle().cos() > 0.0); // positive result
     assert_eq!(squared.length, 1.0);
 
     // this is why (-1) × (-1) = +1: its just π + π = 2π ≡ 0
@@ -2093,8 +2093,8 @@ fn its_a_metric_signature() {
     assert_eq!(blade_diff, 2); // 3 - 1 = 2, encodes dual positive/negative spacetime signature (π angle as -,+)
 
     // prove signature through cosine values - measured from actual blade arithmetic
-    assert!(spatial_squared.angle.mod_4_angle().cos() < 0.0); // spatial blade 1 gives negative cosine
-    assert!(temporal_squared.angle.mod_4_angle().cos() > 0.0); // temporal blade 3 gives positive cosine
+    assert!(spatial_squared.angle.grade_angle().cos() < 0.0); // spatial blade 1 gives negative cosine
+    assert!(temporal_squared.angle.grade_angle().cos() > 0.0); // temporal blade 3 gives positive cosine
 
     // minkowski metric signature emerges: 2 blade difference maintains space/time distinction
 
@@ -2134,13 +2134,13 @@ fn its_a_metric_signature() {
 
         if expected_negative {
             assert!(
-                squared.angle.mod_4_angle().cos() < 0.0,
+                squared.angle.grade_angle().cos() < 0.0,
                 "index {} negative",
                 i
             );
         } else {
             assert!(
-                squared.angle.mod_4_angle().cos() > 0.0,
+                squared.angle.grade_angle().cos() > 0.0,
                 "index {} positive",
                 i
             );
@@ -2156,14 +2156,14 @@ fn its_a_metric_signature() {
     let i_squared_euclidean = i_3d_euclidean * i_3d_euclidean;
 
     // 3π/2 + 3π/2 = 3π ≡ π (mod 2π), cos(π) = -1
-    assert_eq!(i_squared_euclidean.angle.mod_4_angle().cos(), -1.0); // I² = -1 for euclidean
+    assert_eq!(i_squared_euclidean.angle.grade_angle().cos(), -1.0); // I² = -1 for euclidean
 
     // in 4D minkowski: 1 time (π/2) + 3 space (0°)
     let i_4d_minkowski = Geonum::new_with_blade(1.0, 4, 0.0, 1.0); // 4 × π/2 = 2π
     let i_squared_minkowski = i_4d_minkowski * i_4d_minkowski;
 
     // 2π + 2π = 4π ≡ 0 (mod 2π), cos(0) = +1
-    assert_eq!(i_squared_minkowski.angle.mod_4_angle().cos(), 1.0); // I² = +1 for minkowski
+    assert_eq!(i_squared_minkowski.angle.grade_angle().cos(), 1.0); // I² = +1 for minkowski
 
     // the ±1 "mystery" is just whether your total angle is odd or even multiples of π
 


### PR DESCRIPTION
## 0.9.0 (2025-09-19)

### removed
- **BREAKING**: removed `pub fn to_cartesian()` crutch function from `Geonum`
  - function encouraged escaping the geometric domain to raw coordinates
  - all internal usage replaced with inline trigonometry where needed
  - tests updated to use geometric operations (`adj()`, `opp()`) or inline projection

  ### changed
  - `mod_4_blade()` Geonum function changed to `grade_angle()`